### PR TITLE
Use docker when running on Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Run tests
         run: |
           cp tests/scripts/config.sh.example tests/scripts/config.sh
-          .ci/run_container.sh pytest -v
+          CONTAINER_RUNTIME=docker .ci/run_container.sh pytest -v


### PR DESCRIPTION
Currently, podman on Github Actions is using vfs which is very
inefficient. Use docker instead until we figure out how to get
fuse-overlayfs set up.