### PR TITLE
Add a check whether the artifact exists before uploading

### DIFF
--- a/pulpcore/cli/core/artifact.py
+++ b/pulpcore/cli/core/artifact.py
@@ -40,7 +40,10 @@ artifact.add_command(show_by_href)
 @pass_entity_context
 @pass_pulp_context
 def upload(
-    pulp_ctx: PulpContext, artifact_ctx: PulpArtifactContext, file: IO[bytes], chunk_size: int
+    pulp_ctx: PulpContext,
+    artifact_ctx: PulpArtifactContext,
+    file: IO[bytes],
+    chunk_size: int,
 ) -> None:
     artifact_href = artifact_ctx.upload(file, chunk_size)
     result = artifact_ctx.show(artifact_href)

--- a/tests/scripts/test_artifact.sh
+++ b/tests/scripts/test_artifact.sh
@@ -15,3 +15,6 @@ sha256=$(sha256sum test.txt | cut -d' ' -f1)
 expect_succ pulp artifact upload --file test.txt
 expect_succ pulp artifact list --sha256 "$sha256"
 test "$(echo "$OUTPUT" | jq -r length)" -eq "1"
+
+# attempt to reupload the file
+expect_succ pulp artifact upload --file test.txt


### PR DESCRIPTION
I timed this check on my box (6GB of RAM with HDDs) and it adds about 0.6 seconds for a 100MB file, 3s for a 500MB, and 6s for a 1GB file. 

One thing I debated about whether the command should fail if the artifact already exists?