### PR TITLE
Add a workaround for weird export api in < 3.10

### DIFF
--- a/pulpcore/cli/core/context.py
+++ b/pulpcore/cli/core/context.py
@@ -5,6 +5,7 @@ import sys
 import click
 
 from pulpcore.cli.common.context import (
+    PulpContext,
     PulpEntityContext,
 )
 
@@ -73,11 +74,18 @@ class PulpExporterContext(PulpEntityContext):
 
 class PulpExportContext(PulpEntityContext):
     ENTITY = "PulpExport"
-    HREF = "core_pulp_pulp_export_href"
+    HREF = "pulp_pulp_export_href"
     LIST_ID = "exporters_core_pulp_exports_list"
     READ_ID = "exporters_core_pulp_exports_read"
     CREATE_ID = "exporters_core_pulp_exports_create"
     DELETE_ID = "exporters_core_pulp_exports_delete"
+
+    def __init__(self, pulp_ctx: PulpContext) -> None:
+        if not pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+            # Workaround for old HREF_NAME
+            # https://github.com/pulp/pulpcore/pull/1066
+            self.__class__.HREF = "core_pulp_pulp_export_href"
+        super().__init__(pulp_ctx)
 
 
 class PulpGroupContext(PulpEntityContext):

--- a/pulpcore/cli/core/export.py
+++ b/pulpcore/cli/core/export.py
@@ -93,9 +93,12 @@ def run(
 ) -> None:
     exporter_ctx = PulpExporterContext(pulp_ctx)
     exporter_href = exporter_ctx.find(name=exporter)["pulp_href"]
-    params = {
-        export_ctx.HREF: exporter_href,  # TODO This looks WRONG!!!
-    }
+    if pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        params = {exporter_ctx.HREF: exporter_href}
+    else:
+        # Workaround for improperly rendered nested resurce paths
+        # https://github.com/pulp/pulpcore/pull/1066
+        params = {export_ctx.HREF: exporter_href}
 
     body: Dict[str, Any] = dict(full=full)
 


### PR DESCRIPTION
This will be needed if https://github.com/pulp/pulpcore/pull/1066 goes into 3.10.