### PR TITLE
Fix nightly by removing 3.6 from matrix

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,7 +20,6 @@ jobs:
           - "latest"
           - "3.8"
           - "3.7"
-          - "3.6"
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python


### PR DESCRIPTION
We're hitting the following bug when testing against 3.6:

https://github.com/pulp/pulpcore/commit/4739d2680bfc38bcadfeed81cab3e1506cc31284

[noissue]