### PR TITLE
Adding pulp_ansible support

### DIFF
--- a/CHANGES/8079.feature
+++ b/CHANGES/8079.feature
@@ -1,0 +1,1 @@
+Basic CRUD support for Ansible repositories

--- a/CHANGES/8080.feature
+++ b/CHANGES/8080.feature
@@ -1,0 +1,1 @@
+Basic CRUD for Ansible role remotes, use '-t role' after remote to select type

--- a/CHANGES/8081.feature
+++ b/CHANGES/8081.feature
@@ -1,0 +1,1 @@
+Basic CRUD for Ansible collection remotes, use '-t collection' after remote to select type

--- a/CHANGES/8082.feature
+++ b/CHANGES/8082.feature
@@ -1,0 +1,1 @@
+Sync roles/collections with 'pulp ansible repository sync --name {repo_name} --remote {remote_name}'

--- a/pulpcore/cli/ansible/__init__.py
+++ b/pulpcore/cli/ansible/__init__.py
@@ -1,0 +1,22 @@
+import click
+
+from pulpcore.cli.common import main
+from pulpcore.cli.common.context import PulpContext, pass_pulp_context
+from pulpcore.cli.common.generic import version_group
+from pulpcore.cli.ansible.distribution import distribution
+from pulpcore.cli.ansible.remote import remote
+from pulpcore.cli.ansible.repository import repository
+
+
+@main.group()
+@pass_pulp_context
+def ansible(pulp_ctx: PulpContext) -> None:
+    if not pulp_ctx.has_plugin("pulp_ansible"):
+        raise click.ClickException("'pulp_ansible' does not seem to be installed.")
+
+
+ansible.add_command(repository)
+repository.add_command(version_group)
+ansible.add_command(remote)
+ansible.add_command(distribution)
+# TODO add content commands

--- a/pulpcore/cli/ansible/context.py
+++ b/pulpcore/cli/ansible/context.py
@@ -1,0 +1,59 @@
+from pulpcore.cli.common.context import (
+    PulpEntityContext,
+    PulpRepositoryContext,
+    PulpRepositoryVersionContext,
+)
+
+
+# TODO Add Role and Collection Content contexts
+
+
+class PulpAnsibleDistributionContext(PulpEntityContext):
+    ENTITY = "distribution"
+    HREF = "ansible_ansible_distribution_href"
+    LIST_ID = "distributions_ansible_ansible_list"
+    READ_ID = "distributions_ansible_ansible_read"
+    CREATE_ID = "distributions_ansible_ansible_create"
+    UPDATE_ID = "distributions_ansible_ansible_partial_update"
+    DELETE_ID = "distributions_ansible_ansible_delete"
+
+
+class PulpAnsibleRoleRemoteContext(PulpEntityContext):
+    ENTITY = "role remote"
+    HREF = "ansible_role_remote_href"
+    LIST_ID = "remotes_ansible_role_list"
+    READ_ID = "remotes_ansible_role_read"
+    CREATE_ID = "remotes_ansible_role_create"
+    UPDATE_ID = "remotes_ansible_role_partial_update"
+    DELETE_ID = "remotes_ansible_role_delete"
+
+
+class PulpAnsibleCollectionRemoteContext(PulpEntityContext):
+    ENTITY = "collection remote"
+    HREF = "ansible_collection_remote_href"
+    LIST_ID = "remotes_ansible_collection_list"
+    READ_ID = "remotes_ansible_collection_read"
+    CREATE_ID = "remotes_ansible_collection_create"
+    UPDATE_ID = "remotes_ansible_collection_partial_update"
+    DELETE_ID = "remotes_ansible_collection_delete"
+
+
+class PulpAnsibleRepositoryVersionContext(PulpRepositoryVersionContext):
+    HREF = "ansible_ansible_repository_version_href"
+    REPOSITORY_HREF = "ansible_ansible_repository_href"
+    LIST_ID = "repositories_ansible_ansible_versions_list"
+    READ_ID = "repositories_ansible_ansible_versions_read"
+    DELETE_ID = "repositories_ansible_ansible_versions_delete"
+    REPAIR_ID = "repositories_ansible_ansible_versions_repair"
+
+
+class PulpAnsibleRepositoryContext(PulpRepositoryContext):
+    HREF = "ansible_ansible_repository_href"
+    LIST_ID = "repositories_ansible_ansible_list"
+    READ_ID = "repositories_ansible_ansible_read"
+    CREATE_ID = "repositories_ansible_ansible_create"
+    UPDATE_ID = "repositories_ansible_ansible_partial_update"
+    DELETE_ID = "repositories_ansible_ansible_delete"
+    SYNC_ID = "repositories_ansible_ansible_sync"
+    MODIFY_ID = "repositories_ansible_ansible_modify"
+    VERSION_CONTEXT = PulpAnsibleRepositoryVersionContext

--- a/pulpcore/cli/ansible/distribution.py
+++ b/pulpcore/cli/ansible/distribution.py
@@ -1,0 +1,136 @@
+from typing import Optional
+
+import click
+
+
+from pulpcore.cli.common.generic import (
+    list_entities,
+    show_by_name,
+    destroy_by_name,
+)
+from pulpcore.cli.common.context import (
+    PulpContext,
+    pass_pulp_context,
+    pass_entity_context,
+    EntityDefinition,
+)
+from pulpcore.cli.ansible.context import (
+    PulpAnsibleDistributionContext,
+    PulpAnsibleRepositoryContext,
+)
+
+
+@click.group()
+@click.option(
+    "-t",
+    "--type",
+    "distribution_type",
+    type=click.Choice(["ansible"], case_sensitive=False),
+    default="ansible",
+)
+@pass_pulp_context
+@click.pass_context
+def distribution(ctx: click.Context, pulp_ctx: PulpContext, distribution_type: str) -> None:
+    if distribution_type == "ansible":
+        ctx.obj = PulpAnsibleDistributionContext(pulp_ctx)
+    else:
+        raise NotImplementedError()
+
+
+distribution.add_command(list_entities)
+distribution.add_command(show_by_name)
+distribution.add_command(destroy_by_name)
+
+
+# TODO Add content_guard option
+@distribution.command()
+@click.option("--name", required=True)
+@click.option("--base-path", required=True)
+@click.option("--repository", help="name of repository")
+@click.option("--version", type=int, help="version of repository, leave blank for always latest")
+@pass_entity_context
+@pass_pulp_context
+def create(
+    pulp_ctx: PulpContext,
+    distribution_ctx: PulpAnsibleDistributionContext,
+    name: str,
+    base_path: str,
+    repository: Optional[str],
+    version: Optional[int],
+) -> None:
+    """Creates a distribution at base-path for repository's content to be discovered at"""
+    body: EntityDefinition = {"name": name, "base_path": base_path}
+    repo: EntityDefinition = PulpAnsibleRepositoryContext(pulp_ctx).find(name=repository)
+    if version is not None and not repository:
+        click.ClickException("You must set --repository when using version")
+    elif version is not None:
+        body["repository_version"] = f'{repo["versions_href"]}{version}/'
+    elif repository:
+        body["repository"] = repo["pulp_href"]
+    result = distribution_ctx.create(body=body)
+    distribution = distribution_ctx.show(result["created_resources"][0])
+    pulp_ctx.output_result(distribution)
+
+
+@distribution.command()
+@click.option("--name", required=True)
+@click.option("--base-path", help="new base_path")
+@click.option("--repository", type=str, default=None, help="new repository to be served")
+@click.option(
+    "--version",
+    type=int,
+    default=None,
+    help="version of new repository to be served, leave blank for always latest",
+)
+@pass_entity_context
+@pass_pulp_context
+def update(
+    pulp_ctx: PulpContext,
+    distribution_ctx: PulpAnsibleDistributionContext,
+    name: str,
+    base_path: Optional[str],
+    repository: Optional[str],
+    version: Optional[int],
+) -> None:
+    """
+    To remove repository or repository_version fields set --repository to ""
+    """
+    dist_body: EntityDefinition = distribution_ctx.find(name=name)
+    href: str = dist_body["pulp_href"]
+    body: EntityDefinition = dict()
+
+    if base_path:
+        body["base_path"] = base_path
+    if repository is not None:
+        if repository == "":
+            # unset repository or repository version
+            if dist_body["repository"]:
+                body["repository"] = ""
+            elif dist_body["repository_version"]:
+                body["repository_version"] = ""
+        else:
+            repo = PulpAnsibleRepositoryContext(pulp_ctx).find(name=repository)
+            if version is not None:
+                if dist_body["repository"]:
+                    distribution_ctx.update(href, body={"repository": ""})
+                body["repository_version"] = f'{repo["versions_href"]}{version}/'
+            else:
+                if dist_body["repository_version"]:
+                    distribution_ctx.update(href, body={"repository_version": ""})
+                body["repository"] = repo["pulp_href"]
+    elif version is not None:
+        # keep current repository, change version
+        if dist_body["repository"]:
+            distribution_ctx.update(href, body={"repository": ""})
+            body["repository_version"] = f'{dist_body["repository"]}versions/{version}/'
+        elif dist_body["repository_version"]:
+            repository_href, _, _ = dist_body["repository_version"].partition("versions")
+            body["repository_version"] = f"{repository_href}versions/{version}/"
+        else:
+            raise click.ClickException(
+                f"Distribution {name} doesn't have a repository set, "
+                f"please specify the repository to use  with --repository"
+            )
+    distribution_ctx.update(href, body=body)
+    dist_body = distribution_ctx.show(href)
+    pulp_ctx.output_result(dist_body)

--- a/pulpcore/cli/ansible/remote.py
+++ b/pulpcore/cli/ansible/remote.py
@@ -1,0 +1,192 @@
+import click
+
+import yaml
+
+from typing import Any, Dict, Optional
+
+from pulpcore.cli.common.generic import (
+    list_entities,
+    show_by_name,
+    destroy_by_name,
+)
+from pulpcore.cli.common.context import (
+    PulpContext,
+    pass_pulp_context,
+    pass_entity_context,
+    PulpEntityContext,
+    EntityDefinition,
+)
+from pulpcore.cli.ansible.context import (
+    PulpAnsibleRoleRemoteContext,
+    PulpAnsibleCollectionRemoteContext,
+)
+
+
+@click.group()
+@click.option(
+    "-t",
+    "--type",
+    "remote_type",
+    type=click.Choice(["collection", "role"], case_sensitive=False),
+    default="collection",
+    is_eager=True,
+)
+@pass_pulp_context
+@click.pass_context
+def remote(ctx: click.Context, pulp_ctx: PulpContext, remote_type: str) -> None:
+    if remote_type == "role":
+        ctx.obj = PulpAnsibleRoleRemoteContext(pulp_ctx)
+    elif remote_type == "collection":
+        ctx.obj = PulpAnsibleCollectionRemoteContext(pulp_ctx)
+    else:
+        raise NotImplementedError()
+
+
+remote_options = {
+    "ca-cert": (str, "a PEM encoded CA certificate"),
+    "client-cert": (str, "a PEM encoded client certificate"),
+    "client-key": (str, "a PEM encode private key"),
+    "tls-validation": (str, "if True, TLS peer validation must be performed"),
+    "proxy-url": (str, "format: scheme//user:password@host:port"),
+    "username": (str, "used for authentication when syncing"),
+    "password": (str, ""),
+    "download-concurrency": (int, "total number of simultaneous connections"),
+    "policy": (str, "policy to use when downloading"),
+    "total-timeout": (str, "aiohttp.ClientTimeout.total for download connections"),
+    "connect-timeout": (str, "aiohttp.ClientTimeout.connect for download connections"),
+    "sock-connect-timeout": (str, "aiohttp.ClientTimeout.sock_connect for download connections"),
+    "sock-read-timeout": (str, "aiohttp.ClientTimeout.sock_read for download connections"),
+}
+
+
+def check_collection_options(
+    remote_ctx: PulpEntityContext,
+    requirements_file: Any,
+    requirements: Optional[str],
+    auth_url: Optional[str],
+    token: Optional[str],
+) -> EntityDefinition:
+
+    body: EntityDefinition = dict()
+    if isinstance(remote_ctx, PulpAnsibleRoleRemoteContext) and any(
+        [requirements_file, requirements, auth_url, token]
+    ):
+        raise click.ClickException("Options not valid for Role remote, see --help")
+    if requirements_file is not None:
+        body["requirements_file"] = f"{yaml.safe_load(requirements_file)}"
+    elif requirements is not None:
+        body["requirements_file"] = yaml.safe_load(f'"{requirements}"')
+    if auth_url is not None:
+        body["auth_url"] = auth_url
+    if token is not None:
+        body["token"] = token
+    return body
+
+
+remote.add_command(list_entities)
+remote.add_command(show_by_name)
+remote.add_command(destroy_by_name)
+
+
+@remote.command(name="create")
+@click.option("--name", required=True)
+@click.option("--url", required=True)
+@click.option(
+    "--requirements-file",
+    type=click.File(),
+    help="Collections only: a Collection requirements yaml",
+)
+@click.option("--requirements", help="Collections only: a string of a requirements yaml")
+@click.option("--auth-url", help="Collections only: URL to receive a session token")
+@click.option("--token", help="Collections only: token key use for authentication")
+@pass_entity_context
+@pass_pulp_context
+def create(
+    pulp_ctx: PulpContext,
+    remote_ctx: PulpEntityContext,
+    name: str,
+    url: str,
+    requirements_file: Any,
+    requirements: Optional[str],
+    auth_url: Optional[str],
+    token: Optional[str],
+    **remote_options: Dict[str, Any],
+) -> None:
+    """
+    Creates a Collection or Role remote based on -t parameter
+
+    e.g. pulp ansible remote -t role create ...
+    """
+    body: EntityDefinition = {"name": name, "url": url}
+
+    body.update(
+        check_collection_options(
+            remote_ctx=remote_ctx,
+            requirements_file=requirements_file,
+            requirements=requirements,
+            auth_url=auth_url,
+            token=token,
+        )
+    )
+
+    if remote_options:
+        removed_nulls = {k: v for k, v in remote_options.items() if v is not None}
+        body.update(removed_nulls)
+    result = remote_ctx.create(body=body)
+    pulp_ctx.output_result(result)
+
+
+@remote.command(name="update")
+@click.option("--name", required=True)
+@click.option("--url")
+@click.option(
+    "--requirements-file", type=click.File(), help="Collections only: new requirements yaml file"
+)
+@click.option("--requirements", help="Collections only: new yaml string of requirements")
+@click.option("--auth-url", help="Collections only: new authentication url")
+@click.option("--token", help="Collections only: new token for authentication")
+@pass_entity_context
+@pass_pulp_context
+def update(
+    pulp_ctx: PulpContext,
+    remote_ctx: PulpEntityContext,
+    name: str,
+    url: Optional[str],
+    requirements_file: Any,
+    requirements: Optional[str],
+    auth_url: Optional[str],
+    token: Optional[str],
+    **remote_options: Dict[str, Any],
+) -> None:
+    """
+    Use -t to specify the type of the remote you are updating
+
+    e.g. pulp ansible remote -t role update ...
+    """
+    body: EntityDefinition = dict()
+
+    body.update(
+        check_collection_options(
+            remote_ctx=remote_ctx,
+            requirements_file=requirements_file,
+            requirements=requirements,
+            auth_url=auth_url,
+            token=token,
+        )
+    )
+    if url:
+        body["url"] = url
+    if remote_options:
+        removed_nulls = {k: v for k, v in remote_options.items() if v is not None}
+        body.update(removed_nulls)
+
+    remote = remote_ctx.find(name=name)
+    remote_href = remote["pulp_href"]
+    remote_ctx.update(remote_href, body=body)
+    result = remote_ctx.show(remote_href)
+    pulp_ctx.output_result(result)
+
+
+for k, v in remote_options.items():
+    click.option(f"--{k}", type=v[0], help=v[1])(create)
+    click.option(f"--{k}", type=v[0], help=v[1])(update)

--- a/pulpcore/cli/ansible/repository.py
+++ b/pulpcore/cli/ansible/repository.py
@@ -1,0 +1,158 @@
+from typing import Optional
+
+import click
+
+from pulpcore.cli.common.generic import (
+    list_entities,
+    show_by_name,
+    destroy_by_name,
+)
+from pulpcore.cli.common.context import (
+    pass_pulp_context,
+    pass_repository_context,
+    PulpContext,
+    PulpRepositoryContext,
+    EntityDefinition,
+)
+from pulpcore.cli.ansible.context import (
+    PulpAnsibleRoleRemoteContext,
+    PulpAnsibleCollectionRemoteContext,
+    PulpAnsibleRepositoryContext,
+)
+
+
+@click.group()
+@click.option(
+    "-t",
+    "--type",
+    "repo_type",
+    type=click.Choice(["ansible"], case_sensitive=False),
+    default="ansible",
+)
+@pass_pulp_context
+@click.pass_context
+def repository(ctx: click.Context, pulp_ctx: PulpContext, repo_type: str) -> None:
+    if repo_type == "ansible":
+        ctx.obj = PulpAnsibleRepositoryContext(pulp_ctx)
+    else:
+        raise NotImplementedError()
+
+
+repository.add_command(show_by_name)
+repository.add_command(list_entities)
+repository.add_command(destroy_by_name)
+
+
+@repository.command()
+@click.option("--name", required=True)
+@click.option("--description", help="an optional description")
+@click.option("--remote", help="an optional remote to default when syncing")
+@pass_repository_context
+@pass_pulp_context
+def create(
+    pulp_ctx: PulpContext,
+    repository_ctx: PulpRepositoryContext,
+    name: str,
+    description: Optional[str],
+    remote: Optional[str],
+) -> None:
+    """Creates a repository to store Role and Collection content"""
+    repository: EntityDefinition = {"name": name, "description": description}
+    if remote is not None:
+        try:
+            remote_href: str = PulpAnsibleCollectionRemoteContext(pulp_ctx).find(name=remote)[
+                "pulp_href"
+            ]
+        except click.ClickException:
+            remote_href = PulpAnsibleRoleRemoteContext(pulp_ctx).find(name=remote)["pulp_href"]
+        repository["remote"] = remote_href
+
+    result = repository_ctx.create(body=repository)
+    pulp_ctx.output_result(result)
+
+
+@repository.command()
+@click.option("--name", required=True)
+@click.option("--description", help="new optional description")
+@click.option("--remote", help="new optional remote")
+@pass_repository_context
+@pass_pulp_context
+def update(
+    pulp_ctx: PulpContext,
+    repository_ctx: PulpRepositoryContext,
+    name: str,
+    description: Optional[str],
+    remote: Optional[str],
+) -> None:
+    """
+    The description and remote can both be unset using an empty string
+
+    e.g. pulp ansible repository update --name foo --description ""
+    """
+    repository: EntityDefinition = repository_ctx.find(name=name)
+
+    if description is not None:
+        if description == "":
+            # unset the description
+            description = None
+        if description != repository["description"]:
+            repository["description"] = description
+
+    if remote is not None:
+        if remote == "":
+            # unset the remote
+            remote_href: str = ""
+        else:
+            try:
+                remote_href = PulpAnsibleCollectionRemoteContext(pulp_ctx).find(name=remote)[
+                    "pulp_href"
+                ]
+            except click.ClickException:
+                remote_href = PulpAnsibleRoleRemoteContext(pulp_ctx).find(name=remote)["pulp_href"]
+
+        repository["remote"] = remote_href
+
+    repository_ctx.update(repository["pulp_href"], body=repository)
+    result = repository_ctx.show(repository["pulp_href"])
+    pulp_ctx.output_result(result)
+
+
+@repository.command()
+@click.option("--name", required=True)
+@click.option("--remote", help="optional remote name to perform sync with")
+@pass_repository_context
+@pass_pulp_context
+def sync(
+    pulp_ctx: PulpContext,
+    repository_ctx: PulpRepositoryContext,
+    name: str,
+    remote: Optional[str],
+) -> None:
+    """
+    If remote is not specified sync will try to use the default remote associated with
+    the repository
+    """
+    repository: EntityDefinition = repository_ctx.find(name=name)
+    repository_href: str = repository["pulp_href"]
+    body: EntityDefinition = dict()
+
+    if remote:
+        try:
+            remote_href: str = PulpAnsibleCollectionRemoteContext(pulp_ctx).find(name=remote)[
+                "pulp_href"
+            ]
+        except click.ClickException:
+            remote_href = PulpAnsibleRoleRemoteContext(pulp_ctx).find(name=remote)["pulp_href"]
+        body["remote"] = remote_href
+    elif repository["remote"] is None:
+        raise click.ClickException(
+            f"Repository '{name}' does not have a default remote. Please specify with '--remote'."
+        )
+
+    repository_ctx.sync(
+        href=repository_href,
+        body=body,
+    )
+
+
+# TODO Finish 'add' and 'remove' commands when role and collection contexts are implemented

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,10 @@ setup(
     entry_points={
         "console_scripts": "pulp=pulpcore.cli.common:main",
         "pulp_cli.plugins": [
+            "ansible=pulpcore.cli.ansible",
+            "container=pulpcore.cli.container",
             "core=pulpcore.cli.core",
             "file=pulpcore.cli.file",
-            "container=pulpcore.cli.container",
             "rpm=pulpcore.cli.rpm",
         ],
     },

--- a/tests/scripts/config.source
+++ b/tests/scripts/config.source
@@ -10,6 +10,8 @@ FILE_REMOTE_URL="${PULP_FIXTURES_URL}/file/PULP_MANIFEST"
 CONTAINER_REMOTE_URL="https://registry-1.docker.io"
 CONTAINER_IMAGE="hello-world"
 RPM_REMOTE_URL="${PULP_FIXTURES_URL}/rpm-unsigned"
+ANSIBLE_COLLECTION_REMOTE_URL="https://galaxy.ansible.com/"
+ANSIBLE_ROLE_REMOTE_URL="https://galaxy.ansible.com/api/v1/roles/?namespace__name=elastic"
 
 # Configure path to config
 export XDG_CONFIG_HOME="$(dirname "$(realpath "$0")")/config"

--- a/tests/scripts/test_ansible_distribution.sh
+++ b/tests/scripts/test_ansible_distribution.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+# shellcheck source=tests/scripts/config.source
+. "$(dirname "$(realpath "$0")")/config.source"
+
+cleanup() {
+  pulp ansible repository destroy --name "cli_test_ansible_repository" || true
+  pulp ansible distribution destroy --name "cli_test_ansible_distro" || true
+  pulp ansible distribution destroy --name "cli_test_ansible_ver_distro" || true
+}
+trap cleanup EXIT
+
+expect_succ pulp ansible repository create --name "cli_test_ansible_repository"
+
+expect_succ pulp ansible distribution create --name "cli_test_ansible_distro" \
+  --base-path "cli_test_ansible_distro" \
+  --repository "cli_test_ansible_repository"
+
+expect_succ pulp ansible distribution create --name "cli_test_ansible_ver_distro" \
+  --base-path "cli_test_ansible_ver_distro" \
+  --repository "cli_test_ansible_repository" \
+  --version "0"
+
+expect_succ pulp ansible distribution list
+expect_succ pulp ansible distribution show --name "cli_test_ansible_distro"
+expect_succ pulp ansible distribution update --name "cli_test_ansible_distro" --repository ""
+
+expect_succ pulp ansible distribution destroy --name "cli_test_ansible_distro"

--- a/tests/scripts/test_ansible_remote.sh
+++ b/tests/scripts/test_ansible_remote.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# shellcheck source=tests/scripts/config.source
+. "$(dirname "$(realpath "$0")")/config.source"
+
+cleanup() {
+  pulp ansible remote -t "role" destroy --name "cli_test_ansible_role_remote" || true
+  pulp ansible remote -t "collection" destroy --name "cli_test_ansible_collection_remote" || true
+}
+trap cleanup EXIT
+
+expect_succ pulp ansible remote list
+
+expect_succ pulp ansible remote -t "role" create --name "cli_test_ansible_role_remote" --url "$ANSIBLE_ROLE_REMOTE_URL"
+expect_succ pulp ansible remote -t "collection" create --name "cli_test_ansible_collection_remote" --url "$ANSIBLE_COLLECTION_REMOTE_URL"
+expect_succ pulp ansible remote -t "role" list
+expect_succ pulp ansible remote -t "collection" list
+expect_succ pulp ansible remote -t "role" update --name "cli_test_ansible_role_remote" --download-concurrency "5"
+expect_succ pulp ansible remote -t "collection" update --name "cli_test_ansible_collection_remote" --download-concurrency "5"
+expect_fail pulp ansible remote -t "role" update --name "cli_test_ansible_role_remote" --requirements "collections:\n  - robertdebock.ansible_development_environment"
+test "$ERROUTPUT" = "Error: Options not valid for Role remote, see --help"
+expect_succ pulp ansible remote -t "role" destroy --name "cli_test_ansible_role_remote"
+expect_succ pulp ansible remote -t "collection" destroy --name "cli_test_ansible_collection_remote"

--- a/tests/scripts/test_ansible_repository.sh
+++ b/tests/scripts/test_ansible_repository.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# shellcheck source=tests/scripts/config.source
+. "$(dirname "$(realpath "$0")")/config.source"
+
+cleanup() {
+  pulp ansible repository destroy --name "cli_test_ansible_repo" || true
+}
+trap cleanup EXIT
+
+expect_succ pulp ansible repository list
+
+expect_succ pulp ansible repository create --name "cli_test_ansible_repo"
+expect_succ pulp ansible repository update --name "cli_test_ansible_repo" --description "Test repository for CLI tests"
+expect_succ pulp ansible repository list
+expect_succ pulp ansible repository destroy --name "cli_test_ansible_repo"

--- a/tests/scripts/test_ansible_sync.sh
+++ b/tests/scripts/test_ansible_sync.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# shellcheck source=tests/scripts/config.source
+. "$(dirname "$(realpath "$0")")/config.source"
+
+cleanup() {
+  pulp ansible remote -t "role" destroy --name "cli_test_ansible_remote" || true
+  pulp ansible remote -t "collection" destroy --name "cli_test_ansible_collection_remote" || true
+  pulp ansible repository destroy --name "cli_test_ansible_repository" || true
+}
+trap cleanup EXIT
+
+cleanup
+
+# Prepare
+expect_succ pulp ansible remote -t "role" create --name "cli_test_ansible_remote" --url "$ANSIBLE_ROLE_REMOTE_URL"
+expect_succ pulp ansible remote -t "collection" create --name "cli_test_ansible_collection_remote" \
+--url "$ANSIBLE_COLLECTION_REMOTE_URL" --requirements "collections:\n  - robertdebock.ansible_development_environment"
+expect_succ pulp ansible repository create --name "cli_test_ansible_repository"
+
+# Test without remote (should fail)
+expect_fail pulp ansible repository sync --name "cli_test_ansible_repository"
+# Test with remote
+expect_succ pulp ansible repository sync --name "cli_test_ansible_repository" --remote "cli_test_ansible_remote"
+
+# Preconfigure remote
+expect_succ pulp ansible repository update --name "cli_test_ansible_repository" --remote "cli_test_ansible_remote"
+
+# Test with remote
+expect_succ pulp ansible repository sync --name "cli_test_ansible_repository"
+# Test without remote
+expect_succ pulp ansible repository sync --name "cli_test_ansible_repository" --remote "cli_test_ansible_remote"
+
+# Verify sync
+expect_succ pulp ansible repository version --repository "cli_test_ansible_repository" list
+test "$(echo "$OUTPUT" | jq -r length)" -eq 2
+expect_succ pulp ansible repository version --repository "cli_test_ansible_repository" show --version 1
+test "$(echo "$OUTPUT" | jq -r '.content_summary.present."ansible.role".count')" -eq 56
+
+# Test repair the version
+expect_succ pulp ansible repository version --repository "cli_test_ansible_repository" repair --version 1
+test "$(echo "$OUTPUT" | jq -r '.state')" = "completed"
+
+# Delete version again
+expect_succ pulp ansible repository version --repository "cli_test_ansible_repository" destroy --version 1
+
+# Test with collection remote
+expect_succ pulp ansible repository sync --name "cli_test_ansible_repository" --remote "cli_test_ansible_collection_remote"
+
+# Verify sync
+expect_succ pulp ansible repository version --repository "cli_test_ansible_repository" list
+test "$(echo "$OUTPUT" | jq -r length)" -eq 2
+expect_succ pulp ansible repository version --repository "cli_test_ansible_repository" show --version 2
+test "$(echo "$OUTPUT" | jq -r '.content_summary.present."ansible.collection_version".count')" -eq 3
+


### PR DESCRIPTION
This adds basic CRUD support for ansible repositories, role remotes, collection remotes, distributions, and syncing.

fixes: #8079
fixes: #8080
fixes: #8081
fixes: #8082
https://pulp.plan.io/issues/8079
https://pulp.plan.io/issues/8080
https://pulp.plan.io/issues/8081
https://pulp.plan.io/issues/8082