### PR TITLE
WIP: Move entity lookup one level up in command chain

### DIFF
--- a/pulpcore/cli/common/context.py
+++ b/pulpcore/cli/common/context.py
@@ -153,6 +153,10 @@ class PulpEntityContext:
     CREATE_ID: ClassVar[str]
     UPDATE_ID: ClassVar[str]
     DELETE_ID: ClassVar[str]
+
+    # Placeholder for an actual entity, subcommands are supposed to act on
+    entity: Optional[EntityData]
+
     # { "pulp_type" : repository-list-id }
     REPOSITORY_FIND_IDS: Dict[str, str] = {
         "file": "repositories_file_file_list",

--- a/pulpcore/cli/common/generic.py
+++ b/pulpcore/cli/common/generic.py
@@ -48,6 +48,16 @@ def list_entities(
 
 
 @click.command(name="show")
+@pass_entity_context
+@pass_pulp_context
+def show_entity(pulp_ctx: PulpContext, entity_ctx: PulpEntityContext) -> None:
+    """Shows details of an entry"""
+    assert entity_ctx.entity is not None
+    entity = entity_ctx.show(entity_ctx.entity["pulp_href"])
+    pulp_ctx.output_result(entity)
+
+
+@click.command(name="show")
 @click.option("--name", required=True, help="Name of the entry")
 @pass_entity_context
 @pass_pulp_context
@@ -81,6 +91,16 @@ def show_version(
     href = f"{repo_href}versions/{version}"
     result = repository_version_ctx.show(href)
     pulp_ctx.output_result(result)
+
+
+@click.command(name="destroy")
+@pass_entity_context
+def destroy_entity(entity_ctx: PulpEntityContext) -> None:
+    """
+    Destroy an entry
+    """
+    assert entity_ctx.entity is not None
+    entity_ctx.delete(entity_ctx.entity["pulp_href"])
 
 
 @click.command(name="destroy")
@@ -133,7 +153,6 @@ def repair_version(
 
 # Generic repository_version command group
 @click.group(name="version")
-@click.option("--repository", required=True)
 @pass_repository_context
 @pass_pulp_context
 @click.pass_context
@@ -141,10 +160,10 @@ def version_group(
     ctx: click.Context,
     pulp_ctx: PulpContext,
     repository_ctx: PulpRepositoryContext,
-    repository: str,
 ) -> None:
     ctx.obj = repository_ctx.VERSION_CONTEXT(pulp_ctx)
-    ctx.obj.repository = repository_ctx.find(name=repository)
+    assert repository_ctx.entity is not None
+    ctx.obj.repository = repository_ctx.entity
 
 
 version_group.add_command(list_entities)

--- a/pulpcore/cli/common/openapi.py
+++ b/pulpcore/cli/common/openapi.py
@@ -261,7 +261,12 @@ class OpenAPI:
             self.debug_callback(2, f"{data!r}")
         if self.safe_calls_only and method.upper() not in SAFE_METHODS:
             raise OpenAPIError("Call aborted due to safe mode")
-        response: requests.Response = self._session.request(method, url, data=data, headers=headers)
+        try:
+            response: requests.Response = self._session.request(
+                method, url, data=data, headers=headers
+            )
+        except requests.ConnectionError as e:
+            raise OpenAPIError(str(e))
         self.debug_callback(1, f"Response: {response.status_code}")
         if response.text:
             self.debug_callback(3, f"{response.text}")

--- a/pulpcore/cli/core/task.py
+++ b/pulpcore/cli/core/task.py
@@ -1,8 +1,7 @@
-from copy import deepcopy
 import click
 
 from pulpcore.cli.common.generic import (
-    list_entities,
+    list_command,
 )
 from pulpcore.cli.common.context import (
     pass_pulp_context,
@@ -21,14 +20,19 @@ def task(ctx: click.Context, pulp_ctx: PulpContext) -> None:
     ctx.obj = PulpTaskContext(pulp_ctx)
 
 
-# deepcopy to not effect other list subcommands
-list_tasks = deepcopy(list_entities)
-click.option("--name", help="List only tasks with this name.")(list_tasks)
-click.option("--name-contains", "name__contains", help="List only tasks whose name contains this.")(
-    list_tasks
+task.add_command(
+    list_command(
+        extra_options=[
+            click.option("--name", help="List only tasks with this name."),
+            click.option(
+                "--name-contains",
+                "name__contains",
+                help="List only tasks whose name contains this.",
+            ),
+            click.option("--state", help="List only tasks in this state."),
+        ]
+    )
 )
-click.option("--state", help="List only tasks in this state.")(list_tasks)
-task.add_command(list_tasks)
 
 
 @task.command()

--- a/pulpcore/cli/file/__init__.py
+++ b/pulpcore/cli/file/__init__.py
@@ -2,7 +2,6 @@ import click
 
 from pulpcore.cli.common import main
 from pulpcore.cli.common.context import PulpContext, pass_pulp_context
-from pulpcore.cli.common.generic import version_group
 from pulpcore.cli.file.content import content
 from pulpcore.cli.file.distribution import distribution
 from pulpcore.cli.file.publication import publication
@@ -10,16 +9,15 @@ from pulpcore.cli.file.remote import remote
 from pulpcore.cli.file.repository import repository
 
 
-@main.group()
+@main.group(name="file")
 @pass_pulp_context
-def file(pulp_ctx: PulpContext) -> None:
+def file_group(pulp_ctx: PulpContext) -> None:
     if not pulp_ctx.has_plugin("pulp_file"):
         raise click.ClickException("'pulp_file' does not seem to be installed.")
 
 
-file.add_command(repository)
-repository.add_command(version_group)
-file.add_command(remote)
-file.add_command(publication)
-file.add_command(distribution)
-file.add_command(content)
+file_group.add_command(repository)
+file_group.add_command(remote)
+file_group.add_command(publication)
+file_group.add_command(distribution)
+file_group.add_command(content)

--- a/pulpcore/cli/file/repository.py
+++ b/pulpcore/cli/file/repository.py
@@ -1,11 +1,11 @@
-from typing import Optional
+from typing import Any, Optional, cast
 
 import click
 
 from pulpcore.cli.common.generic import (
     list_entities,
-    show_by_name,
-    destroy_by_name,
+    show_entity,
+    destroy_entity,
 )
 from pulpcore.cli.common.context import (
     pass_pulp_context,
@@ -20,6 +20,22 @@ from pulpcore.cli.file.context import (
 )
 
 
+def _name_callback(ctx: click.Context, param: Any, value: str) -> str:
+    group: click.Group = cast(click.Group, ctx.command)
+    if value is not None:
+        group.commands.pop("list", None)
+        group.commands.pop("create", None)
+    else:
+        group.commands.pop("show", None)
+        group.commands.pop("update", None)
+        group.commands.pop("destroy", None)
+        group.commands.pop("sync", None)
+        group.commands.pop("add", None)
+        group.commands.pop("remove", None)
+        group.commands.pop("version", None)
+    return value
+
+
 @click.group()
 @click.option(
     "-t",
@@ -28,16 +44,25 @@ from pulpcore.cli.file.context import (
     type=click.Choice(["file"], case_sensitive=False),
     default="file",
 )
+@click.option("--name", type=str, callback=_name_callback, is_eager=True)
 @pass_pulp_context
 @click.pass_context
-def repository(ctx: click.Context, pulp_ctx: PulpContext, repo_type: str) -> None:
+def repository(
+    ctx: click.Context,
+    pulp_ctx: PulpContext,
+    repo_type: str,
+    name: Optional[str],
+) -> None:
     if repo_type == "file":
         ctx.obj = PulpFileRepositoryContext(pulp_ctx)
     else:
         raise NotImplementedError()
 
+    if name is not None:
+        ctx.obj.entity = ctx.obj.find(name=name)
 
-repository.add_command(show_by_name)
+
+repository.add_command(show_entity)
 repository.add_command(list_entities)
 
 
@@ -64,7 +89,6 @@ def create(
 
 
 @repository.command()
-@click.option("--name", required=True)
 @click.option("--description")
 @click.option("--remote")
 @pass_repository_context
@@ -72,11 +96,11 @@ def create(
 def update(
     pulp_ctx: PulpContext,
     repository_ctx: PulpRepositoryContext,
-    name: str,
     description: Optional[str],
     remote: Optional[str],
 ) -> None:
-    repository = repository_ctx.find(name=name)
+    repository = repository_ctx.entity
+    assert repository is not None
     repository_href = repository["pulp_href"]
 
     if description is not None:
@@ -97,22 +121,20 @@ def update(
     repository_ctx.update(repository_href, body=repository)
 
 
-repository.add_command(destroy_by_name)
-repository.add_command(show_by_name)
+repository.add_command(destroy_entity)
 
 
 @repository.command()
-@click.option("--name", required=True)
 @click.option("--remote")
 @pass_repository_context
 @pass_pulp_context
 def sync(
     pulp_ctx: PulpContext,
     repository_ctx: PulpRepositoryContext,
-    name: str,
     remote: Optional[str],
 ) -> None:
-    repository = repository_ctx.find(name=name)
+    repository = repository_ctx.entity
+    assert repository is not None
     repository_href = repository["pulp_href"]
 
     body = {}
@@ -121,6 +143,7 @@ def sync(
         remote_href: str = PulpFileRemoteContext(pulp_ctx).find(name=remote)["pulp_href"]
         body["remote"] = remote_href
     elif repository["remote"] is None:
+        name = repository["name"]
         raise click.ClickException(
             f"Repository '{name}' does not have a default remote. Please specify with '--remote'."
         )
@@ -132,7 +155,6 @@ def sync(
 
 
 @repository.command()
-@click.option("--name", required=True)
 @click.option("--sha256", required=True)
 @click.option("--relative-path", required=True)
 @click.option("--base-version", type=int)
@@ -141,12 +163,12 @@ def sync(
 def add(
     pulp_ctx: PulpContext,
     repository_ctx: PulpRepositoryContext,
-    name: str,
     sha256: str,
     relative_path: str,
     base_version: Optional[int],
 ) -> None:
-    repository = repository_ctx.find(name=name)
+    repository = repository_ctx.entity
+    assert repository is not None
     repository_href = repository["pulp_href"]
 
     base_version_href: Optional[str]
@@ -167,7 +189,6 @@ def add(
 
 
 @repository.command()
-@click.option("--name", required=True)
 @click.option("--sha256", required=True)
 @click.option("--relative-path", required=True)
 @click.option("--base-version", type=int)
@@ -176,12 +197,12 @@ def add(
 def remove(
     pulp_ctx: PulpContext,
     repository_ctx: PulpRepositoryContext,
-    name: str,
     sha256: str,
     relative_path: str,
     base_version: Optional[int],
 ) -> None:
-    repository = repository_ctx.find(name=name)
+    repository = repository_ctx.entity
+    assert repository is not None
     repository_href = repository["pulp_href"]
 
     base_version_href: Optional[str]

--- a/tests/scripts/test_container_repository.sh
+++ b/tests/scripts/test_container_repository.sh
@@ -4,18 +4,18 @@
 . "$(dirname "$(realpath "$0")")/config.source"
 
 cleanup() {
-  pulp container repository destroy --name "cli_test_container_repo" || true
-  pulp container repository --type push destroy --name "cli_test_container_push_repo" || true
+  pulp container repository --name "cli_test_container_repo" destroy || true
+  pulp container repository --type push --name "cli_test_container_push_repo" destroy || true
 }
 trap cleanup EXIT
 
 expect_succ pulp container repository list
 
 expect_succ pulp container repository create --name "cli_test_container_repo"
-expect_succ pulp container repository show --name "cli_test_container_repo"
-expect_succ pulp container repository update --name "cli_test_container_repo" --description "Test repository for CLI tests"
+expect_succ pulp container repository --name "cli_test_container_repo" show
+expect_succ pulp container repository --name "cli_test_container_repo" update --description "Test repository for CLI tests"
 expect_succ pulp container repository list
-expect_succ pulp container repository destroy --name "cli_test_container_repo"
+expect_succ pulp container repository --name "cli_test_container_repo" destroy
 
 # Skip push repository tests due to https://pulp.plan.io/issues/7839
 # expect_succ pulp container repository --type push list

--- a/tests/scripts/test_container_sync.sh
+++ b/tests/scripts/test_container_sync.sh
@@ -4,8 +4,8 @@
 . "$(dirname "$(realpath "$0")")/config.source"
 
 cleanup() {
-  pulp container remote destroy --name "cli_test_container_remote" || true
-  pulp container repository destroy --name "cli_test_container_repository" || true
+  pulp container remote --name "cli_test_container_remote" destroy || true
+  pulp container repository --name "cli_test_container_repository" destroy || true
 }
 trap cleanup EXIT
 
@@ -14,24 +14,24 @@ pulp container remote create --name "cli_test_container_remote" --url "$CONTAINE
 pulp container repository create --name "cli_test_container_repository"
 
 # Test without remote (should fail)
-expect_fail pulp container repository sync --name "cli_test_container_repository"
+expect_fail pulp container repository --name "cli_test_container_repository" sync
 # Test with remote
-expect_succ pulp container repository sync --name "cli_test_container_repository" --remote "cli_test_container_remote"
+expect_succ pulp container repository --name "cli_test_container_repository" sync --remote "cli_test_container_remote"
 
 # Preconfigure remote
 # TBD
-# pulp container repository update --name "cli_test_container_repository" --remote "cli_test_container_remote"
+# pulp container repository --name "cli_test_container_repository" update --remote "cli_test_container_remote"
 
-# Test with remote
-# expect_succ pulp container repository sync --name "cli_test_container_repository"
 # Test without remote
-# expect_succ pulp container repository sync --name "cli_test_container_repository" --remote "cli_test_container_remote"
+# expect_succ pulp container repository --name "cli_test_container_repository" sync
+# Test with remote
+# expect_succ pulp container repository --name "cli_test_container_repository" sync --remote "cli_test_container_remote"
 
 # Verify sync
-expect_succ pulp container repository version --repository "cli_test_container_repository" list
+expect_succ pulp container repository --name "cli_test_container_repository" version list
 test "$(echo "$OUTPUT" | jq -r length)" -eq 2
-expect_succ pulp container repository version --repository "cli_test_container_repository" show --version 1
+expect_succ pulp container repository --name "cli_test_container_repository" version show --version 1
 test "$(echo "$OUTPUT" | jq -r '.content_summary.present."container.tag".count')" -gt 0
 
 # Delete version again
-expect_succ pulp container repository version --repository "cli_test_container_repository" destroy --version 1
+expect_succ pulp container repository --name "cli_test_container_repository" version destroy --version 1

--- a/tests/scripts/test_file_repository.sh
+++ b/tests/scripts/test_file_repository.sh
@@ -4,13 +4,13 @@
 . "$(dirname "$(realpath "$0")")/config.source"
 
 cleanup() {
-  pulp file repository destroy --name "cli_test_file_repo" || true
+  pulp file repository --name "cli_test_file_repo" destroy || true
 }
 trap cleanup EXIT
 
 expect_succ pulp file repository list
 
 expect_succ pulp file repository create --name "cli_test_file_repo"
-expect_succ pulp file repository update --name "cli_test_file_repo" --description "Test repository for CLI tests"
+expect_succ pulp file repository --name "cli_test_file_repo" update --description "Test repository for CLI tests"
 expect_succ pulp file repository list
-expect_succ pulp file repository destroy --name "cli_test_file_repo"
+expect_succ pulp file repository --name "cli_test_file_repo" destroy

--- a/tests/scripts/test_file_sync.sh
+++ b/tests/scripts/test_file_sync.sh
@@ -5,7 +5,7 @@
 
 cleanup() {
   pulp file remote destroy --name "cli_test_file_remote" || true
-  pulp file repository destroy --name "cli_test_file_repository" || true
+  pulp file repository --name "cli_test_file_repository" destroy || true
 }
 trap cleanup EXIT
 
@@ -16,27 +16,27 @@ expect_succ pulp file remote create --name "cli_test_file_remote" --url "$FILE_R
 expect_succ pulp file repository create --name "cli_test_file_repository"
 
 # Test without remote (should fail)
-expect_fail pulp file repository sync --name "cli_test_file_repository"
+expect_fail pulp file repository --name "cli_test_file_repository" sync
 # Test with remote
-expect_succ pulp file repository sync --name "cli_test_file_repository" --remote "cli_test_file_remote"
+expect_succ pulp file repository --name "cli_test_file_repository" sync --remote "cli_test_file_remote"
 
 # Preconfigure remote
-expect_succ pulp file repository update --name "cli_test_file_repository" --remote "cli_test_file_remote"
+expect_succ pulp file repository --name "cli_test_file_repository" update --remote "cli_test_file_remote"
 
-# Test with remote
-expect_succ pulp file repository sync --name "cli_test_file_repository"
 # Test without remote
-expect_succ pulp file repository sync --name "cli_test_file_repository" --remote "cli_test_file_remote"
+expect_succ pulp file repository --name "cli_test_file_repository" sync
+# Test with remote
+expect_succ pulp file repository --name "cli_test_file_repository" sync --remote "cli_test_file_remote"
 
 # Verify sync
-expect_succ pulp file repository version --repository "cli_test_file_repository" list
+expect_succ pulp file repository --name "cli_test_file_repository" version list
 test "$(echo "$OUTPUT" | jq -r length)" -eq 2
-expect_succ pulp file repository version --repository "cli_test_file_repository" show --version 1
+expect_succ pulp file repository --name "cli_test_file_repository" version show --version 1
 test "$(echo "$OUTPUT" | jq -r '.content_summary.present."file.file".count')" -eq 3
 
 # Test repair the version
-expect_succ pulp file repository version --repository "cli_test_file_repository" repair --version 1
+expect_succ pulp file repository --name "cli_test_file_repository" version repair --version 1
 test "$(echo "$OUTPUT" | jq -r '.state')" = "completed"
 
 # Delete version again
-expect_succ pulp file repository version --repository "cli_test_file_repository" destroy --version 1
+expect_succ pulp file repository --name "cli_test_file_repository" version destroy --version 1

--- a/tests/scripts/test_file_sync.sh
+++ b/tests/scripts/test_file_sync.sh
@@ -31,12 +31,12 @@ expect_succ pulp file repository --name "cli_test_file_repository" sync --remote
 # Verify sync
 expect_succ pulp file repository --name "cli_test_file_repository" version list
 test "$(echo "$OUTPUT" | jq -r length)" -eq 2
-expect_succ pulp file repository --name "cli_test_file_repository" version show --version 1
+expect_succ pulp file repository --name "cli_test_file_repository" version --number 1 show
 test "$(echo "$OUTPUT" | jq -r '.content_summary.present."file.file".count')" -eq 3
 
 # Test repair the version
-expect_succ pulp file repository --name "cli_test_file_repository" version repair --version 1
+expect_succ pulp file repository --name "cli_test_file_repository" version --number 1 repair
 test "$(echo "$OUTPUT" | jq -r '.state')" = "completed"
 
 # Delete version again
-expect_succ pulp file repository --name "cli_test_file_repository" version destroy --version 1
+expect_succ pulp file repository --name "cli_test_file_repository" version --number 1 destroy

--- a/tests/scripts/test_rpm_sync_publish.sh
+++ b/tests/scripts/test_rpm_sync_publish.sh
@@ -5,7 +5,7 @@
 
 cleanup() {
   pulp rpm remote destroy --name "cli_test_rpm_remote" || true
-  pulp rpm repository destroy --name "cli_test_rpm_repository" || true
+  pulp rpm repository --name "cli_test_rpm_repository" destroy || true
   pulp rpm distribution destroy --name "cli_test_rpm_distro" || true
 }
 trap cleanup EXIT
@@ -18,8 +18,8 @@ else
 fi
 
 expect_succ pulp rpm remote create --name "cli_test_rpm_remote" --url "$RPM_REMOTE_URL"
-expect_succ pulp rpm repository create --name "cli_test_rpm_repository" --remote "cli_test_rpm_remote"
-expect_succ pulp rpm repository sync --name "cli_test_rpm_repository"
+expect_succ pulp rpm repository --name "cli_test_rpm_repository" create --remote "cli_test_rpm_remote"
+expect_succ pulp rpm repository --name "cli_test_rpm_repository" sync
 expect_succ pulp rpm publication create --repository "cli_test_rpm_repository"
 PUBLICATION_HREF=$(echo "$OUTPUT" | jq -r .pulp_href)
 
@@ -29,10 +29,10 @@ expect_succ pulp rpm distribution create --name "cli_test_rpm_distro" \
 
 expect_succ curl "$curl_opt" --head --fail "$PULP_BASE_URL/pulp/content/cli_test_rpm_distro/config.repo"
 
-expect_succ pulp rpm repository version --repository "cli_test_rpm_repository" list
-expect_succ pulp rpm repository version --repository "cli_test_rpm_repository" repair --version 1
+expect_succ pulp rpm repository --name "cli_test_rpm_repository" version list
+expect_succ pulp rpm repository --name "cli_test_rpm_repository" version repair --version 1
 
 expect_succ pulp rpm distribution destroy --name "cli_test_rpm_distro"
 expect_succ pulp rpm publication destroy --href "$PUBLICATION_HREF"
-expect_succ pulp rpm repository destroy --name "cli_test_rpm_repository"
+expect_succ pulp rpm repository --name "cli_test_rpm_repository" destroy
 expect_succ pulp rpm remote destroy --name "cli_test_rpm_remote"


### PR DESCRIPTION
This is again the start of a bigger refactoring effort.
But i believe it gives the entity lookup a much more logical place in the command chain.
Also it helps to list the proper available commands when you specify a name.