### PR TITLE
Make container push repositories read-only

### DIFF
--- a/pulpcore/cli/container/context.py
+++ b/pulpcore/cli/container/context.py
@@ -55,9 +55,9 @@ class PulpContainerPushRepositoryContext(PulpRepositoryContext):
     HREF = "container_container_push_repository_href"
     LIST_ID = "repositories_container_container_push_list"
     READ_ID = "repositories_container_container_push_read"
-    CREATE_ID = "repositories_container_container_push_create"
+    # CREATE_ID = "repositories_container_container_push_create"
     # UPDATE_ID = "repositories_container_container_push_update"
-    DELETE_ID = "repositories_container_container_push_delete"
+    # DELETE_ID = "repositories_container_container_push_delete"
     # Cannot sync a push type repository
     # TODO Incorporate into capabilities
     # SYNC_ID = "repositories_container_container_push_sync"

--- a/tests/scripts/test_container_distribution.sh
+++ b/tests/scripts/test_container_distribution.sh
@@ -6,23 +6,14 @@
 cleanup() {
   pulp container repository destroy --name "cli_test_container_repository" || true
   pulp container distribution destroy --name "cli_test_container_distro" || true
-
-  # Push repos delete their distribution automatically
-  pulp container repository --type "push" destroy --name "cli_test_container_push_repository" || true
 }
 trap cleanup EXIT
 
 expect_succ pulp container repository create --name "cli_test_container_repository"
-expect_succ pulp container repository --type "push" create --name "cli_test_container_push_repository"
 
 expect_succ pulp container distribution create --name "cli_test_container_distro" \
   --base-path "cli_test_container_distro" \
   --repository "cli_test_container_repository"
-
-expect_succ pulp container distribution create --name "cli_test_container_push_distro" \
-  --base-path "cli_test_container_push_distro" \
-  --repository "cli_test_container_push_repository" \
-  --repository-type "push"
 
 expect_succ pulp container distribution list
 expect_succ pulp container distribution show --name "cli_test_container_distro"

--- a/tests/scripts/test_container_repository.sh
+++ b/tests/scripts/test_container_repository.sh
@@ -5,7 +5,6 @@
 
 cleanup() {
   pulp container repository destroy --name "cli_test_container_repo" || true
-  pulp container repository --type push destroy --name "cli_test_container_push_repo" || true
 }
 trap cleanup EXIT
 
@@ -16,12 +15,3 @@ expect_succ pulp container repository show --name "cli_test_container_repo"
 expect_succ pulp container repository update --name "cli_test_container_repo" --description "Test repository for CLI tests"
 expect_succ pulp container repository list
 expect_succ pulp container repository destroy --name "cli_test_container_repo"
-
-# Skip push repository tests due to https://pulp.plan.io/issues/7839
-# expect_succ pulp container repository --type push list
-
-# expect_succ pulp container repository --type push create --name "cli_test_container_push_repo"
-# expect_succ pulp container repository --type push show --name "cli_test_container_push_repo"
-# expect_fail pulp container repository --type push update --name "cli_test_container_push_repo" --description "Test repository for CLI tests"
-# expect_succ pulp container repository --type push list
-# expect_succ pulp container repository --type push destroy --name "cli_test_container_push_repo"


### PR DESCRIPTION
ContainerPushRepository is going to be changed. So this removes all
writing action from the commands and to unblock our ci removes all tests
for this repository type for now. We can add them back when the
pulp_container plugin has settled.

[noissue]