### PR TITLE
Support for multi-file transactions in file repo

### DIFF
--- a/CHANGES/8120.feature
+++ b/CHANGES/8120.feature
@@ -1,0 +1,1 @@
+Added subcommand to modify file repository with many content units in one command.

--- a/pulpcore/cli/file/repository.py
+++ b/pulpcore/cli/file/repository.py
@@ -204,7 +204,7 @@ def remove(
 
 def _load_json_from_option(
     ctx: click.Context,
-    option: Any,
+    option_name: Any,
     option_value: str,
 ) -> List[Dict[str, str]]:
     """Load JSON from input string or from file if string starts with @."""
@@ -238,7 +238,9 @@ def _load_json_from_option(
     callback=_load_json_from_option,
     is_eager=True,
     expose_value=True,
-    help="JSON string with a list of objects with the keys 'sha256', 'relative_path'. The argument prefixed with the '@' can be the path to a JSON file with a list of objects.",
+    help="""JSON string with a list of objects to add to the repository.
+    Each object should consist of the following keys: "sha256", "relative_path"..
+    The argument prefixed with the '@' can be the path to a JSON file with a list of objects.""",
 )
 @click.option(
     "--remove-content",
@@ -246,7 +248,9 @@ def _load_json_from_option(
     callback=_load_json_from_option,
     is_eager=True,
     expose_value=True,
-    help="JSON string with a list of objects with the keys 'sha256', 'relative_path'. The argument prefixed with the '@' can be the path to a JSON file with a list of objects.",
+    help="""JSON string with a list of objects to remove from the repository.
+    Each object should consist of the following keys: "sha256", "relative_path"..
+    The argument prefixed with the '@' can be the path to a JSON file with a list of objects.""",
 )
 @pass_repository_context
 @pass_pulp_context

--- a/tests/scripts/test_file_content.sh
+++ b/tests/scripts/test_file_content.sh
@@ -34,5 +34,3 @@ expect_succ pulp file repository add --name "cli_test_file_repository" --sha256 
 expect_succ pulp file repository add --name "cli_test_file_repository" --sha256 "$sha256" --relative-path upload_test/test.txt --base-version 0
 expect_succ pulp file repository remove --name "cli_test_file_repository" --sha256 "$sha256" --relative-path upload_test/test.txt
 expect_succ pulp file repository remove --name "cli_test_file_repository" --sha256 "$sha256" --relative-path upload_test/test.txt --base-version 1
-expect_succ pulp file repository modify --name "cli_test_file_repository" --add-content "[{\"sha256\":\"$sha256\",\"relative_path\":\"upload_test/test.txt\"}]" --base-version 0
-expect_succ pulp file repository modify --name "cli_test_file_repository" --remove-content "[{\"sha256\":\"$sha256\",\"relative_path\":\"upload_test/test.txt\"}]"

--- a/tests/scripts/test_file_content.sh
+++ b/tests/scripts/test_file_content.sh
@@ -34,3 +34,5 @@ expect_succ pulp file repository add --name "cli_test_file_repository" --sha256 
 expect_succ pulp file repository add --name "cli_test_file_repository" --sha256 "$sha256" --relative-path upload_test/test.txt --base-version 0
 expect_succ pulp file repository remove --name "cli_test_file_repository" --sha256 "$sha256" --relative-path upload_test/test.txt
 expect_succ pulp file repository remove --name "cli_test_file_repository" --sha256 "$sha256" --relative-path upload_test/test.txt --base-version 1
+expect_succ pulp file repository modify --name "cli_test_file_repository" --add-content "[{\"sha256\":\"$sha256\",\"relative_path\":\"upload_test/test.txt\"}]" --base-version 0
+expect_succ pulp file repository modify --name "cli_test_file_repository" --remove-content "[{\"sha256\":\"$sha256\",\"relative_path\":\"upload_test/test.txt\"}]"

--- a/tests/scripts/test_file_content_bulk.sh
+++ b/tests/scripts/test_file_content_bulk.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+# shellcheck source=tests/scripts/config.source
+. "$(dirname "$(realpath "$0")")/config.source"
+
+cleanup() {
+  rm test_{1,2,3}.txt
+  rm {add,remove}_content.json
+  pulp file repository destroy --name "cli_test_file_repository" || true
+  pulp orphans delete || true
+}
+trap cleanup EXIT
+
+# Test bulk add to repository
+dd if=/dev/urandom of=test_1.txt bs=2MiB count=1
+sha256_1=$(sha256sum test_1.txt | cut -d' ' -f1)
+dd if=/dev/urandom of=test_2.txt bs=2MiB count=1
+sha256_2=$(sha256sum test_2.txt | cut -d' ' -f1)
+dd if=/dev/urandom of=test_3.txt bs=2MiB count=1
+sha256_3=$(sha256sum test_3.txt | cut -d' ' -f1)
+
+expect_succ pulp artifact upload --file test_1.txt
+expect_succ pulp artifact upload --file test_2.txt
+expect_succ pulp artifact upload --file test_3.txt
+expect_succ pulp file content create --sha256 "$sha256_1" --relative-path upload_test/test_1.txt
+expect_succ pulp file content create --sha256 "$sha256_2" --relative-path upload_test/test_2.txt
+expect_succ pulp file content create --sha256 "$sha256_3" --relative-path upload_test/test_3.txt
+
+expect_succ pulp file repository create --name "cli_test_file_repository"
+
+# Add content using JSON string
+ADD_CONTENT="[{\"sha256\":\"$sha256_1\",\"relative_path\":\"upload_test/test_1.txt\"},{\"sha256\":\"$sha256_2\",\"relative_path\":\"upload_test/test_2.txt\"},{\"sha256\":\"$sha256_3\",\"relative_path\":\"upload_test/test_3.txt\"}]"
+REMOVE_CONTENT=${ADD_CONTENT}
+expect_succ pulp file repository modify --name "cli_test_file_repository" --add-content ${ADD_CONTENT}
+expect_succ pulp file repository modify --name "cli_test_file_repository" --remove-content ${REMOVE_CONTENT}
+
+# Add content using JSON file
+cat <<EOT >> add_content.json
+[
+    {
+        "sha256":"$sha256_1",
+        "relative_path":"upload_test/test_1.txt"
+    },
+    {
+        "sha256":"$sha256_2",
+        "relative_path":"upload_test/test_2.txt"
+    },
+    {
+        "sha256":"$sha256_3",
+        "relative_path":"upload_test/test_3.txt"
+    }
+]
+EOT
+cp add_content.json remove_content.json
+
+expect_succ pulp file repository modify --name "cli_test_file_repository" --add-content "@add_content.json" --base-version 0
+expect_succ pulp file repository modify --name "cli_test_file_repository" --remove-content "@remove_content.json"

--- a/tests/scripts/test_file_content_bulk.sh
+++ b/tests/scripts/test_file_content_bulk.sh
@@ -4,8 +4,8 @@
 . "$(dirname "$(realpath "$0")")/config.source"
 
 cleanup() {
-  rm test_{1,2,3}.txt
-  rm {add,remove}_content.json
+  rm test_1.txt test_2.txt test_3.txt
+  rm add_content.json remove_content.json
   pulp file repository destroy --name "cli_test_file_repository" || true
   pulp orphans delete || true
 }
@@ -29,10 +29,8 @@ expect_succ pulp file content create --sha256 "$sha256_3" --relative-path upload
 expect_succ pulp file repository create --name "cli_test_file_repository"
 
 # Add content using JSON string
-ADD_CONTENT="[{\"sha256\":\"$sha256_1\",\"relative_path\":\"upload_test/test_1.txt\"},{\"sha256\":\"$sha256_2\",\"relative_path\":\"upload_test/test_2.txt\"},{\"sha256\":\"$sha256_3\",\"relative_path\":\"upload_test/test_3.txt\"}]"
-REMOVE_CONTENT=${ADD_CONTENT}
-expect_succ pulp file repository modify --name "cli_test_file_repository" --add-content ${ADD_CONTENT}
-expect_succ pulp file repository modify --name "cli_test_file_repository" --remove-content ${REMOVE_CONTENT}
+expect_succ pulp file repository modify --name "cli_test_file_repository" --add-content "[{\"sha256\":\"$sha256_1\",\"relative_path\":\"upload_test/test_1.txt\"},{\"sha256\":\"$sha256_2\",\"relative_path\":\"upload_test/test_2.txt\"},{\"sha256\":\"$sha256_3\",\"relative_path\":\"upload_test/test_3.txt\"}]"
+expect_succ pulp file repository modify --name "cli_test_file_repository" --remove-content "[{\"sha256\":\"$sha256_1\",\"relative_path\":\"upload_test/test_1.txt\"},{\"sha256\":\"$sha256_2\",\"relative_path\":\"upload_test/test_2.txt\"},{\"sha256\":\"$sha256_3\",\"relative_path\":\"upload_test/test_3.txt\"}]"
 
 # Add content using JSON file
 cat <<EOT >> add_content.json


### PR DESCRIPTION
Added support for adding and removing many file content units from repository using one command.
This feature was already implemented in pulp-file plugin.

fixes #8120