### PR TITLE
Added update command to file distribution

### DIFF
--- a/CHANGES/8145.feature
+++ b/CHANGES/8145.feature
@@ -1,0 +1,1 @@
+Added update command for file distribution.

--- a/pulpcore/cli/file/distribution.py
+++ b/pulpcore/cli/file/distribution.py
@@ -60,4 +60,29 @@ def create(
     pulp_ctx.output_result(distribution)
 
 
+@distribution.command()
+@click.option("--name", required=True)
+@click.option("--base-path")
+@click.option("--publication")
+@pass_entity_context
+@pass_pulp_context
+def update(
+    pulp_ctx: PulpContext,
+    distribution_ctx: PulpFileDistributionContext,
+    name: str,
+    base_path: Optional[str],
+    publication: Optional[str],
+) -> None:
+    distribution = distribution_ctx.find(name=name)
+    distribution_href = distribution["pulp_href"]
+
+    if (base_path is not None) and (base_path != distribution["base_path"]):
+        distribution["base_path"] = base_path
+
+    if publication is not None:
+        distribution["publication"] = None if publication == "" else publication
+
+    distribution_ctx.update(distribution_href, body=distribution)
+
+
 distribution.add_command(destroy_by_name)

--- a/tests/scripts/test_file_distribution.sh
+++ b/tests/scripts/test_file_distribution.sh
@@ -23,7 +23,9 @@ expect_succ pulp file repository sync --name "cli_test_file_repository"
 expect_succ pulp file publication create --repository "cli_test_file_repository"
 PUBLICATION_HREF=$(echo "$OUTPUT" | jq -r .pulp_href)
 
-expect_succ pulp file distribution create --name "cli_test_file_distro" \
+expect_succ pulp file distribution create --name "cli_test_file_distro" --base-path "wrong_path" 
+expect_succ pulp file distribution update \
+  --name "cli_test_file_distro" \
   --base-path "cli_test_file_distro" \
   --publication "$PUBLICATION_HREF"
 

--- a/tests/scripts/test_file_distribution.sh
+++ b/tests/scripts/test_file_distribution.sh
@@ -23,7 +23,13 @@ expect_succ pulp file repository sync --name "cli_test_file_repository"
 expect_succ pulp file publication create --repository "cli_test_file_repository"
 PUBLICATION_HREF=$(echo "$OUTPUT" | jq -r .pulp_href)
 
-expect_succ pulp file distribution create --name "cli_test_file_distro" --base-path "wrong_path" 
+expect_succ pulp file distribution create \
+  --name "cli_test_file_distro" \
+  --base-path "wrong_path" \
+  --publication "$PUBLICATION_HREF"
+expect_succ pulp file distribution update \
+  --name "cli_test_file_distro" \
+  --publication ""
 expect_succ pulp file distribution update \
   --name "cli_test_file_distro" \
   --base-path "cli_test_file_distro" \


### PR DESCRIPTION
Updating file distribution is implemented in pulp API,
but wasn't added to pulp-cli.

This feature allows to change publication and base path
of existing distribution.

fixes #8145
https://pulp.plan.io/issues/8145