### PR TITLE
Fix release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Individual tests can be selected by pattern via `pytest -k file`.
 
 1. Generate the changelog (eg `towncrier --yes --version 0.1.0`) and commit
 1. Run `bumpversion release`, commit your local changes, and note the commit sha
-1. Run `bumpversion patch` to update the version to the next dev release version
+1. Run `bumpversion minor` to update the version to the next dev release version
 1. Push your commits, open a PR, and get it merged
 1. After your PR is merged, pull the latest changes from develop
 1. Now tag your release commit (e.g. `git tag 0.1.0`) and push to pulp/pulp-cli


### PR DESCRIPTION
Given that we don't have release branches and aren't doing patch releases, we should be bumping develop to the next y-release version.