### PR TITLE
Adds fallback component names for plugin checking

### DIFF
--- a/CHANGES/153.feature
+++ b/CHANGES/153.feature
@@ -1,0 +1,4 @@
+In pulpcore 3.11, the component names changed to fix a bug. This ported ``pulp-cli`` to use the new
+names and provides dictionary named ``new_component_names_to_pre_3_11_names`` in the
+``pulpcore.cli.common.context`` module which provides new to old name mappings for a fallback
+support. ``pulp-cli`` plugins can add to this list by importing and modifying that dictionary also.

--- a/pulpcore/cli/ansible/__init__.py
+++ b/pulpcore/cli/ansible/__init__.py
@@ -12,7 +12,7 @@ _ = gettext.gettext
 @main.group()
 @pass_pulp_context
 def ansible(pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin("pulp_ansible")
+    pulp_ctx.needs_plugin("ansible")
 
 
 ansible.add_command(repository)

--- a/pulpcore/cli/common/context.py
+++ b/pulpcore/cli/common/context.py
@@ -32,6 +32,15 @@ EntityDefinition = Dict[str, Any]
 RepositoryDefinition = Tuple[str, str]  # name, pulp_type
 RepositoryVersionDefinition = Tuple[str, str, int]  # name, pulp_type, version
 
+new_component_names_to_pre_3_11_names: Dict[str, str] = dict(
+    ansible="pulp_ansible",
+    container="pulp_container",
+    core="pulpcore",
+    deb="pulp_deb",
+    file="pulp_file",
+    rpm="pulp_rpm",
+)
+
 
 class PulpNoWait(click.ClickException):
     exit_code = 0
@@ -169,7 +178,10 @@ class PulpContext:
             return (min_version is None) and (max_version is None)
         version: Optional[str] = self.component_versions.get(name)
         if version is None:
-            return False
+            pre_3_11_name: str = new_component_names_to_pre_3_11_names.get(name, "")
+            version = self.component_versions.get(pre_3_11_name)
+            if version is None:
+                return False
         if min_version is not None:
             if parse_version(version) < parse_version(min_version):
                 return False

--- a/pulpcore/cli/container/__init__.py
+++ b/pulpcore/cli/container/__init__.py
@@ -12,7 +12,7 @@ _ = gettext.gettext
 @main.group()
 @pass_pulp_context
 def container(pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin("pulp_container")
+    pulp_ctx.needs_plugin("container")
 
 
 container.add_command(repository)

--- a/pulpcore/cli/core/context.py
+++ b/pulpcore/cli/core/context.py
@@ -22,7 +22,7 @@ class PulpAccessPolicyContext(PulpEntityContext):
     def find(self, **kwargs: Any) -> Any:
         """Workaroud for the missing ability to filter"""
         # https://pulp.plan.io/issues/8189
-        if self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround not needed anymore
             return super().find(**kwargs)
         search_result = self.list(limit=sys.maxsize, offset=0, parameters={})
@@ -106,7 +106,7 @@ class PulpExportContext(PulpEntityContext):
     exporter: EntityDefinition
 
     def list(self, limit: int, offset: int, parameters: Dict[str, Any]) -> List[Any]:
-        if not self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if not self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround for improperly rendered nested resource paths and weird HREF names
             # https://github.com/pulp/pulpcore/pull/1066
             parameters[PulpExporterContext.HREF] = self.exporter["pulp_href"]
@@ -118,7 +118,7 @@ class PulpExportContext(PulpEntityContext):
         parameters: Optional[Dict[str, Any]] = None,
         non_blocking: bool = False,
     ) -> Any:
-        if not self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if not self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround for improperly rendered nested resource paths and weird HREF names
             # https://github.com/pulp/pulpcore/pull/1066
             if parameters is None:
@@ -128,7 +128,7 @@ class PulpExportContext(PulpEntityContext):
 
     @property
     def HREF(self) -> str:  # type: ignore
-        if not self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if not self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround for improperly rendered nested resource paths and weird HREF names
             # https://github.com/pulp/pulpcore/pull/1066
             return "core_pulp_pulp_export_href"
@@ -136,7 +136,7 @@ class PulpExportContext(PulpEntityContext):
 
     @property
     def scope(self) -> Dict[str, Any]:
-        if not self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if not self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround for improperly rendered nested resource paths and weird HREF names
             # https://github.com/pulp/pulpcore/pull/1066
             return {}
@@ -154,7 +154,7 @@ class PulpGroupContext(PulpEntityContext):
 
     def find(self, **kwargs: Any) -> Any:
         """Workaroud for the missing ability to filter"""
-        if self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround not needed anymore
             return super().find(**kwargs)
         # See https://pulp.plan.io/issues/7975
@@ -172,7 +172,7 @@ class PulpGroupPermissionContext(PulpEntityContext):
     group_ctx: PulpGroupContext
 
     def __init__(self, pulp_ctx: PulpContext, group_ctx: PulpGroupContext) -> None:
-        pulp_ctx.needs_plugin("pulpcore", min_version="3.10.dev0")
+        pulp_ctx.needs_plugin("core", min_version="3.10.dev")
         super().__init__(pulp_ctx)
         self.group_ctx = group_ctx
 
@@ -180,7 +180,7 @@ class PulpGroupPermissionContext(PulpEntityContext):
         """Workaroud for the missing ability to filter"""
         # # TODO fix upstream and adjust to guard for the proper version
         # # https://pulp.plan.io/issues/8241
-        # if self.pulp_ctx.has_plugin("pulpcore", min_version="3.99.dev0"):
+        # if self.pulp_ctx.has_plugin("core", min_version="3.99.dev"):
         #     # Workaround not needed anymore
         #     return super().find(**kwargs)
         search_result = self.list(limit=sys.maxsize, offset=0, parameters={})
@@ -229,7 +229,7 @@ class PulpGroupUserContext(PulpEntityContext):
         self.group_ctx = group_ctx
 
     def list(self, limit: int, offset: int, parameters: Dict[str, Any]) -> List[Any]:
-        if not self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if not self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround for improperly rendered nested resource paths and weird HREF names
             # https://github.com/pulp/pulpcore/pull/1066
             parameters[PulpGroupContext.HREF] = self.group_ctx.pulp_href
@@ -241,7 +241,7 @@ class PulpGroupUserContext(PulpEntityContext):
         parameters: Optional[Dict[str, Any]] = None,
         non_blocking: bool = False,
     ) -> Any:
-        if not self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if not self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround for improperly rendered nested resource paths and weird HREF names
             # https://github.com/pulp/pulpcore/pull/1066
             if parameters is None:
@@ -251,7 +251,7 @@ class PulpGroupUserContext(PulpEntityContext):
 
     @property
     def HREF(self) -> str:  # type: ignore
-        if not self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if not self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround for improperly rendered nested resource paths and weird HREF names
             # https://github.com/pulp/pulpcore/pull/1066
             return "auth_auth_groups_user_href"
@@ -259,7 +259,7 @@ class PulpGroupUserContext(PulpEntityContext):
 
     @property
     def scope(self) -> Dict[str, Any]:
-        if not self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if not self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround for improperly rendered nested resource paths and weird HREF names
             # https://github.com/pulp/pulpcore/pull/1066
             return {}
@@ -317,7 +317,7 @@ class PulpUserContext(PulpEntityContext):
 
     def find(self, **kwargs: Any) -> Any:
         """Workaroud for the missing ability to filter"""
-        if self.pulp_ctx.has_plugin("pulpcore", min_version="3.10.dev0"):
+        if self.pulp_ctx.has_plugin("core", min_version="3.10.dev"):
             # Workaround not needed anymore
             return super().find(**kwargs)
         # See https://pulp.plan.io/issues/7975

--- a/pulpcore/cli/core/repository.py
+++ b/pulpcore/cli/core/repository.py
@@ -18,7 +18,7 @@ def repository(ctx: click.Context, pulp_ctx: PulpContext) -> None:
     Please look for the plugin specific repository commands for more detailed actions.
     i.e. 'pulp file repository <...>'
     """
-    pulp_ctx.needs_plugin("pulpcore", min_version="3.10.dev")
+    pulp_ctx.needs_plugin("core", min_version="3.10.dev")
     ctx.obj = PulpRepositoryContext(pulp_ctx)
 
 

--- a/pulpcore/cli/file/__init__.py
+++ b/pulpcore/cli/file/__init__.py
@@ -14,7 +14,7 @@ _ = gettext.gettext
 @main.group(name="file")
 @pass_pulp_context
 def file_group(pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin("pulp_file")
+    pulp_ctx.needs_plugin("file")
 
 
 file_group.add_command(repository)

--- a/pulpcore/cli/rpm/__init__.py
+++ b/pulpcore/cli/rpm/__init__.py
@@ -13,7 +13,7 @@ _ = gettext.gettext
 @main.group()
 @pass_pulp_context
 def rpm(pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin("pulp_rpm")
+    pulp_ctx.needs_plugin("rpm")
 
 
 rpm.add_command(repository)

--- a/tests/scripts/pulp_ansible/test_distribution.sh
+++ b/tests/scripts/pulp_ansible/test_distribution.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_ansible" || exit 3
+pulp debug has-plugin --name "ansible" || exit 3
 
 cleanup() {
   pulp ansible repository destroy --name "cli_test_ansible_repository" || true

--- a/tests/scripts/pulp_ansible/test_remote.sh
+++ b/tests/scripts/pulp_ansible/test_remote.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_ansible" || exit 3
+pulp debug has-plugin --name "ansible" || exit 3
 
 cleanup() {
   pulp ansible remote -t "role" destroy --name "cli_test_ansible_role_remote" || true

--- a/tests/scripts/pulp_ansible/test_repository.sh
+++ b/tests/scripts/pulp_ansible/test_repository.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_ansible" || exit 3
+pulp debug has-plugin --name "ansible" || exit 3
 
 cleanup() {
   pulp ansible repository destroy --name "cli_test_ansible_repo" || true

--- a/tests/scripts/pulp_ansible/test_sync.sh
+++ b/tests/scripts/pulp_ansible/test_sync.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_ansible" || exit 3
+pulp debug has-plugin --name "ansible" || exit 3
 
 cleanup() {
   pulp ansible remote -t "role" destroy --name "cli_test_ansible_remote" || true

--- a/tests/scripts/pulp_container/test_distribution.sh
+++ b/tests/scripts/pulp_container/test_distribution.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_container" || exit 3
+pulp debug has-plugin --name "container" || exit 3
 
 cleanup() {
   pulp container repository destroy --name "cli_test_container_repository" || true

--- a/tests/scripts/pulp_container/test_remote.sh
+++ b/tests/scripts/pulp_container/test_remote.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_container" || exit 3
+pulp debug has-plugin --name "container" || exit 3
 
 cleanup() {
   pulp container remote destroy --name "cli_test_container_remote" || true

--- a/tests/scripts/pulp_container/test_repository.sh
+++ b/tests/scripts/pulp_container/test_repository.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_container" || exit 3
+pulp debug has-plugin --name "container" || exit 3
 
 cleanup() {
   pulp container repository destroy --name "cli_test_container_repo" || true

--- a/tests/scripts/pulp_container/test_sync.sh
+++ b/tests/scripts/pulp_container/test_sync.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_container" || exit 3
+pulp debug has-plugin --name "container" || exit 3
 
 cleanup() {
   pulp container remote destroy --name "cli_test_container_remote" || true

--- a/tests/scripts/pulp_file/test_content.sh
+++ b/tests/scripts/pulp_file/test_content.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp file repository destroy --name "cli_test_file_repository" || true

--- a/tests/scripts/pulp_file/test_content_bulk.sh
+++ b/tests/scripts/pulp_file/test_content_bulk.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp file repository destroy --name "cli_test_file_repository" || true

--- a/tests/scripts/pulp_file/test_distribution.sh
+++ b/tests/scripts/pulp_file/test_distribution.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp file remote destroy --name "cli_test_file_remote" || true

--- a/tests/scripts/pulp_file/test_label.sh
+++ b/tests/scripts/pulp_file/test_label.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulpcore" --min-version "3.10.0" || exit 3
+pulp debug has-plugin --name "core" --min-version "3.10.0" || exit 3
 
 cleanup() {
   pulp file repository destroy --name "cli_test_file_repo" || true

--- a/tests/scripts/pulp_file/test_publication.sh
+++ b/tests/scripts/pulp_file/test_publication.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp file remote destroy --name "cli_test_file_remote" || true

--- a/tests/scripts/pulp_file/test_remote.sh
+++ b/tests/scripts/pulp_file/test_remote.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp file remote destroy --name "cli_test_file_remote" || true

--- a/tests/scripts/pulp_file/test_repository.sh
+++ b/tests/scripts/pulp_file/test_repository.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp file repository destroy --name "cli_test_file_repo" || true
@@ -30,7 +30,7 @@ expect_succ test "$(echo "$OUTPUT" | jq -r '.description')" = "null"
 expect_succ test "$(echo "$OUTPUT" | jq -r '.remote')" = ""
 expect_succ pulp file repository list
 test "$(echo "$OUTPUT" | jq -r '.|length')" != "0"
-if pulp debug has-plugin --name "pulpcore" --min-version "3.10.dev"
+if pulp debug has-plugin --name "core" --min-version "3.10.dev"
 then
   expect_succ pulp repository list
   test "$(echo "$OUTPUT" | jq -r '.|length')" != "0"

--- a/tests/scripts/pulp_file/test_sync.sh
+++ b/tests/scripts/pulp_file/test_sync.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp file remote destroy --name "cli_test_file_remote" || true

--- a/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
+++ b/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_rpm" || exit 3
+pulp debug has-plugin --name "rpm" || exit 3
 
 cleanup() {
   pulp rpm remote destroy --name "cli_test_rpm_remote" || true

--- a/tests/scripts/pulpcore/test_group_permissions.sh
+++ b/tests/scripts/pulpcore/test_group_permissions.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulpcore" --min-version "3.10.dev" || exit 3
+pulp debug has-plugin --name "core" --min-version "3.10.dev" || exit 3
 
 cleanup() {
   pulp group destroy --name "cli_test_group" || true

--- a/tests/scripts/pulpcore/test_pulpexporter.sh
+++ b/tests/scripts/pulpcore/test_pulpexporter.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 RMOTE="cli_test_file_remote"
 REPO1="cli_test_pulpexporter_repository_1"

--- a/tests/scripts/pulpcore/test_pulpimporter.sh
+++ b/tests/scripts/pulpcore/test_pulpimporter.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp importer pulp destroy --name "cli_test_importer" || true

--- a/tests/scripts/pulpcore/test_show.sh
+++ b/tests/scripts/pulpcore/test_show.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp file repository destroy --name "cli_test_file_repo" || true

--- a/tests/scripts/pulpcore/test_task.sh
+++ b/tests/scripts/pulpcore/test_task.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "pulp_file" || exit 3
+pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
   pulp file remote destroy --name "cli_test_file_remote" || true

--- a/tests/scripts/pulpcore/test_worker.sh
+++ b/tests/scripts/pulpcore/test_worker.sh
@@ -13,7 +13,7 @@ expect_succ pulp worker list --online
 expect_succ pulp worker list --not-online
 expect_succ pulp worker list --name "resource-manager"
 
-if pulp debug has-plugin --name "pulpcore" --min-version "3.10.0"
+if pulp debug has-plugin --name "core" --min-version "3.10.0"
 then
   expect_succ pulp worker list --name-contains "resource"
 fi


### PR DESCRIPTION
In pulpcore 3.11, the component changed to fix a bug. This switches
the names of existing plugins to use the new names. It also adds
fallback support to allow pulpcore<3.11 names to continue working which
will be removed in a future release.

Additionally plugins can add in additional fallback names by adding to
the `new_component_names_to_pre_3_11_names` in the
`pulpcore.cli.common.context` module.

Fixes #153