### PR TITLE
Add proxy username and password to remote

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -3,7 +3,7 @@ strict = True
 show_error_codes = True
 files = pulpcore/**/*.py
 
-[mypy-urllib3]
+[mypy-urllib3.*]
 ignore_missing_imports = True
 
 [mypy-pygments.*]

--- a/pulpcore/cli/file/context.py
+++ b/pulpcore/cli/file/context.py
@@ -3,6 +3,7 @@ import gettext
 from pulpcore.cli.common.context import (
     EntityDefinition,
     PulpEntityContext,
+    PulpRemoteContext,
     PulpRepositoryContext,
     PulpRepositoryVersionContext,
 )
@@ -57,7 +58,7 @@ class PulpFilePublicationContext(PulpEntityContext):
         return body
 
 
-class PulpFileRemoteContext(PulpEntityContext):
+class PulpFileRemoteContext(PulpRemoteContext):
     ENTITY = "file remote"
     ENTITIES = "file remotes"
     HREF = "file_file_remote_href"

--- a/pulpcore/cli/file/remote.py
+++ b/pulpcore/cli/file/remote.py
@@ -50,6 +50,8 @@ create_options = [
         "--policy", type=click.Choice(["immediate", "on_demand", "streamed"], case_sensitive=False)
     ),
     click.option("--proxy-url"),
+    click.option("--proxy-username"),
+    click.option("--proxy-password"),
     click.option("--sock-connect-timeout", type=float),
     click.option("--sock-read-timeout", type=float),
     click.option("--tls-validation", type=bool),
@@ -68,6 +70,8 @@ update_options = [
         "--policy", type=click.Choice(["immediate", "on_demand", "streamed"], case_sensitive=False)
     ),
     click.option("--proxy-url"),
+    click.option("--proxy-username"),
+    click.option("--proxy-password"),
     click.option("--sock-connect-timeout", type=float),
     click.option("--sock-read-timeout", type=float),
     click.option("--tls-validation", type=bool),

--- a/tests/scripts/pulp_file/test_remote.sh
+++ b/tests/scripts/pulp_file/test_remote.sh
@@ -12,7 +12,7 @@ trap cleanup EXIT
 
 expect_succ pulp file remote list
 
-expect_succ pulp file remote create --name "cli_test_file_remote" --url "$FILE_REMOTE_URL"
+expect_succ pulp file remote create --name "cli_test_file_remote" --url "$FILE_REMOTE_URL" --proxy-url "http://proxy.org" --proxy-username "user" --proxy-password "pass"
 expect_succ pulp file remote show --name "cli_test_file_remote"
 expect_succ pulp file remote list
 expect_succ pulp file remote destroy --name "cli_test_file_remote"


### PR DESCRIPTION
This is combined with a workaround for pulpcore < 3.11 to insert the
credentials into the proxy_url.

[noissue]