### PR TITLE
Added new content subgroup to repository commands

### DIFF
--- a/CHANGES/171.feature
+++ b/CHANGES/171.feature
@@ -1,0 +1,1 @@
+Repository content commands are now nested under a new content subgroup.

--- a/CHANGES/215.removal
+++ b/CHANGES/215.removal
@@ -1,0 +1,1 @@
+Repository add/remove/modify commands have now been deprecated. Please use the new content subgroup commands.

--- a/pulpcore/cli/common/context.py
+++ b/pulpcore/cli/common/context.py
@@ -587,6 +587,16 @@ class PulpRepositoryContext(PulpEntityContext):
         )
 
 
+class PulpContentContext(PulpEntityContext):
+    """
+    Base class for content specific contexts
+    """
+
+    ENTITY = "content"
+    ENTITIES = "content"
+    LIST_ID = "content_list"
+
+
 EntityFieldDefinition = Union[None, str, PulpEntityContext]
 ##############################################################################
 # Decorator to access certain contexts
@@ -596,3 +606,4 @@ pass_pulp_context = click.make_pass_decorator(PulpContext)
 pass_entity_context = click.make_pass_decorator(PulpEntityContext)
 pass_repository_context = click.make_pass_decorator(PulpRepositoryContext)
 pass_repository_version_context = click.make_pass_decorator(PulpRepositoryVersionContext)
+pass_content_context = click.make_pass_decorator(PulpContentContext)

--- a/pulpcore/cli/file/context.py
+++ b/pulpcore/cli/file/context.py
@@ -2,6 +2,7 @@ import gettext
 
 from pulpcore.cli.common.context import (
     EntityDefinition,
+    PulpContentContext,
     PulpEntityContext,
     PulpRemoteContext,
     PulpRepositoryContext,
@@ -11,7 +12,7 @@ from pulpcore.cli.common.context import (
 _ = gettext.gettext
 
 
-class PulpFileContentContext(PulpEntityContext):
+class PulpFileContentContext(PulpContentContext):
     ENTITY = "file content"
     ENTITIES = "file content"
     HREF = "file_file_content_href"

--- a/pulpcore/cli/python/context.py
+++ b/pulpcore/cli/python/context.py
@@ -3,6 +3,7 @@ from typing import ClassVar
 from pulpcore.cli.common.context import (
     EntityDefinition,
     PluginRequirement,
+    PulpContentContext,
     PulpEntityContext,
     PulpRemoteContext,
     PulpRepositoryContext,
@@ -10,9 +11,9 @@ from pulpcore.cli.common.context import (
 )
 
 
-class PulpPythonContentContext(PulpEntityContext):
-    ENTITY = "python content"
-    ENTITIES = "python content"
+class PulpPythonContentContext(PulpContentContext):
+    ENTITY = "python package"
+    ENTITIES = "python packages"
     HREF = "python_python_package_content_href"
     LIST_ID = "content_python_packages_list"
     READ_ID = "content_python_packages_read"

--- a/tests/scripts/pulp_file/test_content_bulk.sh
+++ b/tests/scripts/pulp_file/test_content_bulk.sh
@@ -28,6 +28,7 @@ expect_succ pulp file content create --sha256 "$sha256_3" --relative-path upload
 
 expect_succ pulp file repository create --name "cli_test_file_repository"
 
+# Old content commands
 # Add content using JSON string
 expect_succ pulp file repository modify --name "cli_test_file_repository" --add-content "[{\"sha256\":\"$sha256_1\",\"relative_path\":\"upload_test/test_1.txt\"},{\"sha256\":\"$sha256_2\",\"relative_path\":\"upload_test/test_2.txt\"},{\"sha256\":\"$sha256_3\",\"relative_path\":\"upload_test/test_3.txt\"}]"
 expect_succ pulp file repository modify --name "cli_test_file_repository" --remove-content "[{\"sha256\":\"$sha256_1\",\"relative_path\":\"upload_test/test_1.txt\"},{\"sha256\":\"$sha256_2\",\"relative_path\":\"upload_test/test_2.txt\"},{\"sha256\":\"$sha256_3\",\"relative_path\":\"upload_test/test_3.txt\"}]"
@@ -53,3 +54,11 @@ cp add_content.json remove_content.json
 
 expect_succ pulp file repository modify --name "cli_test_file_repository" --add-content "@-" --base-version 0 < add_content.json
 expect_succ pulp file repository modify --name "cli_test_file_repository" --remove-content "@remove_content.json"
+
+# New Content commands
+expect_succ pulp file repository content modify --repository "cli_test_file_repository" --add-content "[{\"sha256\":\"$sha256_1\",\"relative_path\":\"upload_test/test_1.txt\"},{\"sha256\":\"$sha256_2\",\"relative_path\":\"upload_test/test_2.txt\"},{\"sha256\":\"$sha256_3\",\"relative_path\":\"upload_test/test_3.txt\"}]"
+expect_succ pulp file repository content list --repository "cli_test_file_repository"
+test "$(echo "$OUTPUT" | jq -r length)" -eq "3"
+expect_succ pulp file repository content modify --repository "cli_test_file_repository" --remove-content "@remove_content.json"
+expect_succ pulp file repository content list --repository "cli_test_file_repository"
+test "$(echo "$OUTPUT" | jq -r length)" -eq "0"


### PR DESCRIPTION
fixes: #171

@mdellweg I marked the current repository content commands as deprecated to give time for users to update their usage to the new commands, but I can remove them if you want me to. 

I set up the factory to allow for plugins that have multiple content types (ansible) and for plugins that have content that requires multiple fields for uniqueness (ansible, file).  This requires some complex dynamic option generation in the factory, but I think the tradeoff is worth for the ease of adding this content subgroup to new plugins.  