### PR TITLE
Pin click requirement <8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     package_data={package: ["py.typed"] for package in packages},
     python_requires=">=3.6",
     install_requires=[
-        "click",
+        "click<8.0.0",
         "click-shell",
         "packaging",
         "PyYAML",


### PR DESCRIPTION
The new release of click breaks our requirement on click_shell.

[noissue]