### PR TITLE
Make click-shell an optional dependency

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -8,8 +8,9 @@ section on how to configure pulp-cli.
 ### From PyPI
 
 ```
+pip install pulp-cli  # minimal dependencies
 pip install pulp-cli[pygments]  # colorized output
-pip install pulp-cli  # no color output
+pip install pulp-cli[shell]  # with interactive shell mode
 ```
 
 ### From a source checkout

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -1,3 +1,9 @@
+# Interactive shell mode
+
+* To use the shell mode, you need to install the the extra requirements tagged "shell". *
+
+** Warning: currently the click-shell dependency is incompatible with the latest version of click. Please install a version of click < 8.0.0. **
+
 Starting the CLI with "pulp shell" drops you into the shell:
 ```
 (pulp) [vagrant@pulp3 ~]$ pulp shell

--- a/pulpcore/cli/common/__init__.py
+++ b/pulpcore/cli/common/__init__.py
@@ -6,7 +6,13 @@ from typing import Any, Optional
 import click
 import pkg_resources
 import toml
-from click_shell import make_click_shell
+
+try:
+    from click_shell import make_click_shell
+
+    HAS_CLICK_SHELL = True
+except ImportError:
+    HAS_CLICK_SHELL = False
 
 from pulpcore.cli.common.config import CONFIG_LOCATION, config, config_options, validate_config
 from pulpcore.cli.common.context import PulpContext
@@ -130,16 +136,18 @@ main.add_command(config)
 main.add_command(debug)
 
 
-@main.command("shell")
-@click.pass_context
-def pulp_shell(ctx: click.Context) -> None:
-    """Activate an interactive shell-mode"""
-    make_click_shell(
-        ctx.parent,
-        prompt="pulp> ",
-        intro="Starting Pulp3 interactive shell...",
-        hist_file=os.path.join(click.utils.get_app_dir("pulp"), "cli-history"),
-    ).cmdloop()
+if HAS_CLICK_SHELL:
+
+    @main.command("shell")
+    @click.pass_context
+    def pulp_shell(ctx: click.Context) -> None:
+        """Activate an interactive shell-mode"""
+        make_click_shell(
+            ctx.parent,
+            prompt="pulp> ",
+            intro="Starting Pulp3 interactive shell...",
+            hist_file=os.path.join(click.utils.get_app_dir("pulp"), "cli-history"),
+        ).cmdloop()
 
 
 ##############################################################################

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,6 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "click<8.0.0",
-        "click-shell~=2.0",
         "packaging",
         "PyYAML~=5.4.1",
         "requests~=2.25.1",
@@ -30,6 +29,7 @@ setup(
     ],
     extras_require={
         "pygments": ["pygments"],
+        "shell": ["click-shell~=2.0"],
     },
     entry_points={
         "console_scripts": "pulp=pulpcore.cli.common:main",


### PR DESCRIPTION
There is no way i found, to make the cli depend on click <9 normally, but <8 if the shell extension is installed.

Maybe we can do smething like this only after https://github.com/clarkperkins/click-shell/pull/29 has been resolved.