### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: 🐛 Bug report
+about: Create a report to help us improve the cli
+labels: bug
+
+---
+
+## Summary
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to reproduce
+<!-- Steps to reproduce the behavior. Please list actual cli commands. -->
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Stacktrace/Error log
+<!-- If possible, add a stacktrace and/or logs -->
+
+## Pulp and pulp-cli version info
+<!-- Verbatim output of `pulp --version` and `pulp status` -->
+
+## Additonal context
+<!-- Add any other context about the problem here. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: ✨ Feature request
+about: Suggest an idea for this project
+labels: feature request
+
+---
+
+## Summary
+<!-- Include any api information. Pulpcore features should be opened against pulpcore, not here. -->
+
+## Examples
+<!-- If applicable, include some proposed cli command examples -->
+<!-- If applicable, include some related httpie call examples -->
+


### PR DESCRIPTION
When you go to create an issue, there is an option to create a blank (ie uncategorized issue). So I think two templates (one for bug and one for feature) should probably suffice.

Here's an example from foreman: https://github.com/theforeman/foreman-ansible-modules/issues/new/choose