### PR TITLE
Mention CLI examples can be found elsewhere

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,8 @@
 
 This is the documentation for Pulp 3's command line interface.
 
+Here you can find information about how to install the Pulp 3 CLI, and general usage and syntax information.
+
+You can find more workflow examples for the Pulp 3 CLI throughout the [plugin documentation](https://docs.pulpproject.org/pulpcore/plugins/index.html). For example, [synchronizing a File repository](https://docs.pulpproject.org/pulp_file/workflows/sync.html).
+
 Use the links on the left to navigate.


### PR DESCRIPTION
There seems to be some confusion around where to find Pulp CLI example workflows. 
I just thought it might help to raise awareness that there are CLI examples throughout our docs. 