### PR TITLE
Stop using find_namespace_packages

### DIFF
--- a/CHANGES/248.bugfix
+++ b/CHANGES/248.bugfix
@@ -1,0 +1,1 @@
+Use ``find_packages`` instead of ``find_namespace_packages`` in setup to be compatible with ``setuptools<39.2.0``.

--- a/pulp_cli/__init__.py
+++ b/pulp_cli/__init__.py
@@ -1,0 +1,1 @@
+from pulpcore.cli.common import main  # noqa: F401

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,27 @@
-from setuptools import find_namespace_packages, setup
+from setuptools import setup
 
-plugin_packages = find_namespace_packages(include=["pulpcore.cli.*"])
-packages = plugin_packages + ["pytest_pulp_cli"]
-plugin_packages.remove("pulpcore.cli.common")
-plugin_entry_points = [(package.rsplit(".", 1)[-1], package) for package in plugin_packages]
+try:
+    from setuptools import find_namespace_packages
+
+    main_entrypoint = "pulp=pulpcore.cli.common:main"
+    plugin_packages = find_namespace_packages(include=["pulpcore.cli.*"])
+    extra_packages = ["pytest_pulp_cli"]
+
+except ImportError:
+    # Old versions of setuptools do not provide `find_namespace_packages`
+    # see https://github.com/pulp/pulp-cli/issues/248
+    from setuptools import find_packages
+
+    main_entrypoint = "pulp=pulp_cli:main"
+    plugins = find_packages(where="pulpcore/cli")
+    plugin_packages = [f"pulpcore.cli.{plugin}" for plugin in plugins]
+    extra_packages = ["pulp_cli", "pytest_pulp_cli"]
+
+plugin_entry_points = [
+    (package.rsplit(".", 1)[-1], package)
+    for package in plugin_packages
+    if package != "pulpcore.cli.common"
+]
 
 long_description = ""
 with open("README.md") as readme:
@@ -20,11 +38,11 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/pulp/pulp-cli",
     version="0.10.0.dev",
-    packages=packages,
+    packages=plugin_packages + extra_packages,
     package_data={package: ["py.typed"] for package in plugin_packages},
     python_requires=">=3.6",
     install_requires=[
-        "click~=8.0.1",
+        "click>=7.1.2,<9.0.0",
         "packaging",
         "PyYAML~=5.4.1",
         "requests~=2.25.1",
@@ -35,7 +53,7 @@ setup(
         "shell": ["click-shell~=2.1"],
     },
     entry_points={
-        "console_scripts": ["pulp=pulpcore.cli.common:main"],
+        "console_scripts": [main_entrypoint],
         "pulp_cli.plugins": [f"{name}={module}" for name, module in plugin_entry_points],
     },
     license="GPLv2+",


### PR DESCRIPTION
Also provide the shell entrypoint in a not namespaced module.
This provides compatibility with older versions of setuptools.

fixes #248

Co-authored-by: Evgeni Golov <evgeni@golov.de>