### PR TITLE
Fix docs publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,5 +52,5 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run publish docs script
       env:
-        PUBLISH_DOCS_KEY: ${{ secrets.PUBLISH_DOCS_KEY }}
+        PULP_DOCS_KEY: ${{ secrets.PULP_DOCS_KEY }}
       run: .ci/scripts/publish_docs.sh ${{ github.ref }}

--- a/CHANGES/286.bugfix
+++ b/CHANGES/286.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in the docs publishing workflow.


### PR DESCRIPTION
I have no idea, how to rerun the workflow without making a new release.
Maybe @daviddavis you can publish the docs by hand once more?