### PR TITLE
don't configure verify_ssl=False for Katello

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -85,7 +85,6 @@ configure client certificate authentication in your `~/.config/pulp/settings.tom
 base_url = "https://<your FQDN>"
 cert = "/etc/pki/katello/certs/pulp-client.crt"
 key = "/etc/pki/katello/private/pulp-client.key"
-verify_ssl = false
 ```
 
 As Katello uses Pulp as a backend all modifying actions in Pulp should be performed via Katello.


### PR DESCRIPTION
Katello does deploy its certs to the system store properly, so once you have set `base_url` to the FQDN, you can verify the chain just fine.