### PR TITLE
Add --uuid for task commands

### DIFF
--- a/pulpcore/cli/core/task.py
+++ b/pulpcore/cli/core/task.py
@@ -1,13 +1,37 @@
 import gettext
+from typing import Optional
 
 import click
 
-from pulpcore.cli.common.context import PulpContext, pass_entity_context, pass_pulp_context
-from pulpcore.cli.common.generic import list_command
+from pulpcore.cli.common.context import (
+    PulpContext,
+    PulpEntityContext,
+    pass_entity_context,
+    pass_pulp_context,
+)
+from pulpcore.cli.common.generic import href_option, list_command, pulp_option
 from pulpcore.cli.core.context import PulpTaskContext
 from pulpcore.cli.core.generic import task_filter
 
 _ = gettext.gettext
+
+
+def _uuid_callback(
+    ctx: click.Context, param: click.Parameter, value: Optional[str]
+) -> Optional[str]:
+    if value is not None:
+        entity_ctx = ctx.find_object(PulpEntityContext)
+        assert entity_ctx is not None
+        entity_ctx.pulp_href = f"/pulp/api/v3/tasks/{value}/"
+    return value
+
+
+uuid_option = pulp_option(
+    "--uuid",
+    help=_("UUID of the {entity}"),
+    callback=_uuid_callback,
+    expose_value=False,
+)
 
 
 @click.group()
@@ -21,34 +45,42 @@ task.add_command(list_command(decorators=task_filter))
 
 
 @task.command()
-@click.option("--href", required=True, help=_("HREF of the task"))
+@href_option
+@uuid_option
 @click.option("-w", "--wait", is_flag=True, help=_("Wait for the task to finish"))
 @pass_entity_context
 @pass_pulp_context
-def show(pulp_ctx: PulpContext, task_ctx: PulpTaskContext, href: str, wait: bool) -> None:
+def show(pulp_ctx: PulpContext, task_ctx: PulpTaskContext, wait: bool) -> None:
     """Shows details of a task."""
-    entity = task_ctx.show(href)
+    entity = task_ctx.entity
     if wait and entity["state"] in ["waiting", "running", "canceling"]:
-        click.echo(f"Waiting for task {href} to finish.", err=True)
+        click.echo(
+            _("Waiting for task {href} to finish.").format(href=task_ctx.pulp_href), err=True
+        )
         entity = pulp_ctx.wait_for_task(entity)
     pulp_ctx.output_result(entity)
 
 
 @task.command()
-@click.option("--href", required=True, help=_("HREF of the task"))
+@href_option
+@uuid_option
 @pass_entity_context
 @pass_pulp_context
-def cancel(pulp_ctx: PulpContext, task_ctx: PulpTaskContext, href: str) -> None:
+def cancel(pulp_ctx: PulpContext, task_ctx: PulpTaskContext) -> None:
     """Cancels a task and waits until the cancellation is confirmed."""
-    entity = task_ctx.show(href)
+    entity = task_ctx.entity
     if entity["state"] not in ["waiting", "running"]:
-        click.ClickException(f"Task {href} is in state {entity['state']} and cannot be canceled.")
+        click.ClickException(
+            _("Task {href} is in state {state} and cannot be canceled.").format(
+                href=task_ctx.pulp_href, state=entity["state"]
+            )
+        )
 
-    task_ctx.cancel(href)
-    click.echo(f"Waiting to cancel task {href}", err=True)
+    task_ctx.cancel(task_ctx.pulp_href)
+    click.echo(_("Waiting to cancel task {href}").format(href=task_ctx.pulp_href), err=True)
     try:
         pulp_ctx.wait_for_task(entity)
     except Exception as e:
         if str(e) != "Task canceled":
             raise e
-    click.echo("Done.", err=True)
+    click.echo(_("Done."), err=True)

--- a/tests/scripts/pulpcore/test_task.sh
+++ b/tests/scripts/pulpcore/test_task.sh
@@ -24,7 +24,7 @@ expect_succ pulp file remote create --name "cli_test_file_large_remote" \
 expect_succ pulp file repository create --name "cli_test_file_repository" --remote "cli_test_file_large_remote"
 
 # Test canceling a task
-if [ "$(pulp debug has-plugin --name "core" --min-version "3.12.0")" = "true" ]
+if pulp debug has-plugin --name "core" --min-version "3.12.0"
 then
   expect_succ pulp --background file repository sync --name "cli_test_file_repository"
   task="$(echo "$ERROUTPUT" | grep -E -o "/pulp/api/v3/tasks/[-[:xdigit:]]*/")"
@@ -38,7 +38,9 @@ fi
 # Test waiting for a task
 expect_succ pulp --background file repository sync --name "cli_test_file_repository" --remote "cli_test_file_remote"
 task=$(echo "$ERROUTPUT" | grep -E -o "/pulp/api/v3/tasks/[-[:xdigit:]]*/")
-expect_succ pulp task show --wait --href "$task"
+task_uuid="${task%/}"
+task_uuid="${task_uuid##*/}"
+expect_succ pulp task show --wait --uuid "$task_uuid"
 expect_succ test "$(echo "$OUTPUT" | jq -r '.state')" = "completed"
 
 expect_succ pulp task list --name-contains file


### PR DESCRIPTION
The workers only log the uuid of tasks. This way it will be easier to
take that information and work with tasks.