### PR TITLE
Bump pulpcore version requirement to >= 3.11

### DIFF
--- a/CHANGES/380.removal
+++ b/CHANGES/380.removal
@@ -1,0 +1,1 @@
+Bumped required pulpcore version to >=3.11 and removed legacy workarounds.

--- a/pulpcore/cli/ansible/__init__.py
+++ b/pulpcore/cli/ansible/__init__.py
@@ -13,7 +13,7 @@ _ = gettext.gettext
 @main.group()
 @pass_pulp_context
 def ansible(pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin(PluginRequirement("ansible"))
+    pulp_ctx.needs_plugin(PluginRequirement("ansible", min="0.7"))
 
 
 ansible.add_command(repository)

--- a/pulpcore/cli/ansible/context.py
+++ b/pulpcore/cli/ansible/context.py
@@ -99,7 +99,7 @@ class PulpAnsibleRepositoryContext(PulpRepositoryContext):
     SYNC_ID = "repositories_ansible_ansible_sync"
     MODIFY_ID = "repositories_ansible_ansible_modify"
     VERSION_CONTEXT = PulpAnsibleRepositoryVersionContext
-    CAPABILITIES = {"pulpexport": [PluginRequirement("ansible", "0.7.0")]}
+    CAPABILITIES = {"pulpexport": [PluginRequirement("ansible")]}
 
 
 registered_repository_contexts["ansible:ansible"] = PulpAnsibleRepositoryContext

--- a/pulpcore/cli/ansible/distribution.py
+++ b/pulpcore/cli/ansible/distribution.py
@@ -78,7 +78,6 @@ distribution.add_command(create_command(decorators=create_options))
 distribution.add_command(
     label_command(
         need_plugins=[
-            PluginRequirement("core", "3.10.0"),
             PluginRequirement("ansible", "0.8.0.dev"),
         ]
     )

--- a/pulpcore/cli/common/__init__.py
+++ b/pulpcore/cli/common/__init__.py
@@ -15,7 +15,7 @@ except ImportError:
     HAS_CLICK_SHELL = False
 
 from pulpcore.cli.common.config import CONFIG_LOCATIONS, config, config_options, validate_config
-from pulpcore.cli.common.context import PulpContext
+from pulpcore.cli.common.context import PluginRequirement, PulpContext
 from pulpcore.cli.common.debug import debug
 
 _ = gettext.gettext
@@ -133,6 +133,7 @@ def main(
     ctx.obj = PulpContext(
         api_kwargs=api_kwargs, format=format, background_tasks=background, timeout=timeout
     )
+    ctx.obj.needs_plugin(PluginRequirement("core", min="3.11"))
 
 
 main.add_command(config)

--- a/pulpcore/cli/common/generic.py
+++ b/pulpcore/cli/common/generic.py
@@ -704,7 +704,7 @@ def label_command(**kwargs: Any) -> click.Command:
     if "name" not in kwargs:
         kwargs["name"] = "label"
     decorators = kwargs.pop("decorators", [name_option, href_option])
-    need_plugins = kwargs.pop("need_plugins", [PluginRequirement("core", "3.10.0")])
+    need_plugins = kwargs.pop("need_plugins", [])
 
     @click.group(**kwargs)
     @pass_pulp_context
@@ -780,8 +780,6 @@ def repository_content_command(**kwargs: Any) -> click.Group:
         type: Optional[str],
         **params: Any,
     ) -> None:
-        if type == "all":
-            pulp_ctx.needs_plugin(PluginRequirement("core", "3.11.0"))
         parameters = {k: v for k, v in params.items() if v is not None}
         parameters.update({"repository_version": version.pulp_href})
         result = content_contexts[type](pulp_ctx).list(

--- a/pulpcore/cli/container/__init__.py
+++ b/pulpcore/cli/container/__init__.py
@@ -13,7 +13,7 @@ _ = gettext.gettext
 @main.group()
 @pass_pulp_context
 def container(pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin(PluginRequirement("container"))
+    pulp_ctx.needs_plugin(PluginRequirement("container", min="2.3"))
 
 
 container.add_command(repository)

--- a/pulpcore/cli/container/context.py
+++ b/pulpcore/cli/container/context.py
@@ -1,8 +1,4 @@
 import gettext
-import sys
-from typing import Any
-
-import click
 
 from pulpcore.cli.common.context import (
     EntityDefinition,
@@ -25,22 +21,6 @@ class PulpContainerNamespaceContext(PulpEntityContext):
     READ_ID = "pulp_container_namespaces_read"
     CREATE_ID = "pulp_container_namespaces_create"
     DELETE_ID = "pulp_container_namespaces_delete"
-
-    def find(self, **kwargs: Any) -> Any:
-        """Workaroud for the missing ability to filter"""
-        if self.pulp_ctx.has_plugin(PluginRequirement("container", min="2.3")):
-            # Workaround not needed anymore
-            return super().find(**kwargs)
-        search_result = self.list(limit=sys.maxsize, offset=0, parameters={})
-        for key, value in kwargs.items():
-            search_result = [res for res in search_result if res[key] == value]
-        if len(search_result) != 1:
-            raise click.ClickException(
-                _("Could not find {entity} with {kwargs}.").format(
-                    entity=self.ENTITY, kwargs=kwargs
-                )
-            )
-        return search_result[0]
 
 
 class PulpContainerDistributionContext(PulpEntityContext):

--- a/pulpcore/cli/core/content.py
+++ b/pulpcore/cli/core/content.py
@@ -2,12 +2,7 @@ import gettext
 
 import click
 
-from pulpcore.cli.common.context import (
-    PluginRequirement,
-    PulpContentContext,
-    PulpContext,
-    pass_pulp_context,
-)
+from pulpcore.cli.common.context import PulpContentContext, PulpContext, pass_pulp_context
 from pulpcore.cli.common.generic import list_command
 
 _ = gettext.gettext
@@ -23,7 +18,6 @@ def content(ctx: click.Context, pulp_ctx: PulpContext) -> None:
     Please look for the plugin specific content commands for more detailed actions.
     i.e. 'pulp file content <...>'
     """
-    pulp_ctx.needs_plugin(PluginRequirement("core", min="3.10"))
     ctx.obj = PulpContentContext(pulp_ctx)
 
 

--- a/pulpcore/cli/core/repository.py
+++ b/pulpcore/cli/core/repository.py
@@ -2,12 +2,7 @@ import gettext
 
 import click
 
-from pulpcore.cli.common.context import (
-    PluginRequirement,
-    PulpContext,
-    PulpRepositoryContext,
-    pass_pulp_context,
-)
+from pulpcore.cli.common.context import PulpContext, PulpRepositoryContext, pass_pulp_context
 from pulpcore.cli.common.generic import list_command
 
 _ = gettext.gettext
@@ -23,7 +18,6 @@ def repository(ctx: click.Context, pulp_ctx: PulpContext) -> None:
     Please look for the plugin specific repository commands for more detailed actions.
     i.e. 'pulp file repository <...>'
     """
-    pulp_ctx.needs_plugin(PluginRequirement("core", min="3.10"))
     ctx.obj = PulpRepositoryContext(pulp_ctx)
 
 

--- a/pulpcore/cli/core/signing_service.py
+++ b/pulpcore/cli/core/signing_service.py
@@ -2,7 +2,7 @@ import gettext
 
 import click
 
-from pulpcore.cli.common.context import PluginRequirement, PulpContext, pass_pulp_context
+from pulpcore.cli.common.context import PulpContext, pass_pulp_context
 from pulpcore.cli.common.generic import href_option, list_command, name_option, show_command
 from pulpcore.cli.core.context import PulpSigningServiceContext
 
@@ -13,7 +13,6 @@ _ = gettext.gettext
 @pass_pulp_context
 @click.pass_context
 def signing_service(ctx: click.Context, pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin(PluginRequirement("core", min="3.10.dev"))
     ctx.obj = PulpSigningServiceContext(pulp_ctx)
 
 

--- a/pulpcore/cli/file/__init__.py
+++ b/pulpcore/cli/file/__init__.py
@@ -15,7 +15,7 @@ _ = gettext.gettext
 @main.group(name="file")
 @pass_pulp_context
 def file_group(pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin(PluginRequirement("file"))
+    pulp_ctx.needs_plugin(PluginRequirement("file", min="1.6"))
 
 
 file_group.add_command(repository)

--- a/pulpcore/cli/file/context.py
+++ b/pulpcore/cli/file/context.py
@@ -102,7 +102,7 @@ class PulpFileRepositoryContext(PulpRepositoryContext):
     SYNC_ID = "repositories_file_file_sync"
     MODIFY_ID = "repositories_file_file_modify"
     VERSION_CONTEXT = PulpFileRepositoryVersionContext
-    CAPABILITIES = {"pulpexport": [PluginRequirement("file", "0.3.0")]}
+    CAPABILITIES = {"pulpexport": [PluginRequirement("file")]}
 
 
 registered_repository_contexts["file:file"] = PulpFileRepositoryContext

--- a/pulpcore/cli/python/__init__.py
+++ b/pulpcore/cli/python/__init__.py
@@ -10,7 +10,7 @@ from pulpcore.cli.python.repository import repository
 @main.group(name="python")
 @pass_pulp_context
 def python_group(pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin(PluginRequirement("python", min="3.1.0.dev"))
+    pulp_ctx.needs_plugin(PluginRequirement("python", min="3.1"))
 
 
 python_group.add_command(repository)

--- a/pulpcore/cli/rpm/__init__.py
+++ b/pulpcore/cli/rpm/__init__.py
@@ -13,7 +13,7 @@ _ = gettext.gettext
 @main.group()
 @pass_pulp_context
 def rpm(pulp_ctx: PulpContext) -> None:
-    pulp_ctx.needs_plugin(PluginRequirement("rpm"))
+    pulp_ctx.needs_plugin(PluginRequirement("rpm", min="3.9"))
 
 
 rpm.add_command(repository)

--- a/pulpcore/cli/rpm/context.py
+++ b/pulpcore/cli/rpm/context.py
@@ -83,7 +83,7 @@ class PulpRpmRepositoryContext(PulpRepositoryContext):
     DELETE_ID = "repositories_rpm_rpm_delete"
     SYNC_ID = "repositories_rpm_rpm_sync"
     VERSION_CONTEXT = PulpRpmRepositoryVersionContext
-    CAPABILITIES = {"pulpexport": [PluginRequirement("rpm", "3.3.0")]}
+    CAPABILITIES = {"pulpexport": [PluginRequirement("rpm")]}
 
 
 registered_repository_contexts["rpm:rpm"] = PulpRpmRepositoryContext

--- a/tests/scripts/pulp_ansible/test_distribution.sh
+++ b/tests/scripts/pulp_ansible/test_distribution.sh
@@ -27,13 +27,10 @@ expect_succ pulp ansible distribution list
 expect_succ pulp ansible distribution show --name "cli_test_ansible_distro"
 expect_succ pulp ansible distribution update --name "cli_test_ansible_distro" --repository ""
 
-if [ "$(pulp debug has-plugin --name "core" --min-version "3.10.0")" = "true" ]
+if [ "$(pulp debug has-plugin --name "ansible" --min-version "0.8.0.dev")" = "true" ]
 then
-  if [ "$(pulp debug has-plugin --name "ansible" --min-version "0.8.0.dev")" = "true" ]
-  then
-    expect_succ pulp ansible distribution label set --name "cli_test_ansible_distro" --key "test" --value "success"
-  else
-    expect_fail pulp ansible distribution label set --name "cli_test_ansible_distro" --key "test" --value "fail"
-  fi
+  expect_succ pulp ansible distribution label set --name "cli_test_ansible_distro" --key "test" --value "success"
+else
+  expect_fail pulp ansible distribution label set --name "cli_test_ansible_distro" --key "test" --value "fail"
 fi
 expect_succ pulp ansible distribution destroy --name "cli_test_ansible_distro"

--- a/tests/scripts/pulp_file/test_content.sh
+++ b/tests/scripts/pulp_file/test_content.sh
@@ -42,19 +42,11 @@ expect_succ pulp file repository content add --repository "cli_test_file_reposit
 expect_succ pulp file repository content add --repository "cli_test_file_repository" --sha256 "$sha256" --relative-path upload_test/test.txt --base-version 0
 expect_succ pulp file repository content list --repository "cli_test_file_repository" --version 1
 test "$(echo "$OUTPUT" | jq -r length)" -eq "1"
-if [ "$(pulp debug has-plugin --name "core" --min-version "3.11.0")" = "true" ]
-then
-  expect_succ pulp file repository content list --repository "cli_test_file_repository" --type "all"
-else
-  expect_fail pulp file repository content list --repository "cli_test_file_repository" --type "all"
-fi
+expect_succ pulp file repository content list --repository "cli_test_file_repository" --type "all"
 
 expect_succ pulp file repository content remove --repository "cli_test_file_repository" --sha256 "$sha256" --relative-path upload_test/test.txt
 expect_succ pulp file repository content list --repository "cli_test_file_repository"
 test "$(echo "$OUTPUT" | jq -r length)" -eq "0"
 
-if pulp debug has-plugin --name "core" --min-version "3.10"
-then
-  expect_succ pulp content list
-  test "$(echo "$OUTPUT" | jq -r length)" -gt "0"
-fi
+expect_succ pulp content list
+test "$(echo "$OUTPUT" | jq -r length)" -gt "0"

--- a/tests/scripts/pulp_file/test_repository.sh
+++ b/tests/scripts/pulp_file/test_repository.sh
@@ -45,17 +45,15 @@ then
   expect_succ pulp file repository update --name "cli_test_file_repo" --manifest "manifest.csv"
 fi
 
-if pulp debug has-plugin --name "core" --min-version "3.10"
-then
-  expect_succ pulp repository list
-  test "$(echo "$OUTPUT" | jq -r '.|length')" != "0"
-  expect_succ pulp repository list --name "cli_test_file_repo"
-  test "$(echo "$OUTPUT" | jq -r '.|length')" = "1"
-  expect_succ pulp repository list --name-contains "cli_test_file"
-  test "$(echo "$OUTPUT" | jq -r '.|length')" = "1"
-  expect_succ pulp repository list --name-icontains "CLI_test_file"
-  test "$(echo "$OUTPUT" | jq -r '.|length')" = "1"
-  expect_succ pulp repository list --name-in "cli_test_file_repo"
-  test "$(echo "$OUTPUT" | jq -r '.|length')" = "1"
-fi
+expect_succ pulp repository list
+test "$(echo "$OUTPUT" | jq -r '.|length')" != "0"
+expect_succ pulp repository list --name "cli_test_file_repo"
+test "$(echo "$OUTPUT" | jq -r '.|length')" = "1"
+expect_succ pulp repository list --name-contains "cli_test_file"
+test "$(echo "$OUTPUT" | jq -r '.|length')" = "1"
+expect_succ pulp repository list --name-icontains "CLI_test_file"
+test "$(echo "$OUTPUT" | jq -r '.|length')" = "1"
+expect_succ pulp repository list --name-in "cli_test_file_repo"
+test "$(echo "$OUTPUT" | jq -r '.|length')" = "1"
+
 expect_succ pulp file repository destroy --name "cli_test_file_repo"

--- a/tests/scripts/pulp_python/test_content.sh
+++ b/tests/scripts/pulp_python/test_content.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "python" --min-version "3.1.0.dev" || exit 3
+pulp debug has-plugin --name "python" || exit 3
 
 cleanup() {
   rm "shelf-reader-0.1.tar.gz"

--- a/tests/scripts/pulp_python/test_distribution.sh
+++ b/tests/scripts/pulp_python/test_distribution.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "python" --min-version "3.1.0.dev" || exit 3
+pulp debug has-plugin --name "python" || exit 3
 
 cleanup() {
   pulp python remote destroy --name "cli_test_python_remote" || true

--- a/tests/scripts/pulp_python/test_publication.sh
+++ b/tests/scripts/pulp_python/test_publication.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "python" --min-version "3.1.0.dev" || exit 3
+pulp debug has-plugin --name "python" || exit 3
 
 cleanup() {
   pulp python remote destroy --name "cli_test_python_remote" || true

--- a/tests/scripts/pulp_python/test_remote.sh
+++ b/tests/scripts/pulp_python/test_remote.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "python" --min-version "3.1.0.dev" || exit 3
+pulp debug has-plugin --name "python" || exit 3
 
 cleanup() {
   pulp python remote destroy --name "cli_test_python_remote" || true

--- a/tests/scripts/pulp_python/test_repository.sh
+++ b/tests/scripts/pulp_python/test_repository.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "python" --min-version "3.1.0.dev" || exit 3
+pulp debug has-plugin --name "python" || exit 3
 
 cleanup() {
   pulp python repository destroy --name "cli_test_python_repo" || true

--- a/tests/scripts/pulp_python/test_sync.sh
+++ b/tests/scripts/pulp_python/test_sync.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "python" --min-version "3.1.0.dev" || exit 3
+pulp debug has-plugin --name "python" || exit 3
 
 cleanup() {
   pulp python remote destroy --name "cli_test_python_remote" || true

--- a/tests/scripts/pulpcore/test_group_permissions.sh
+++ b/tests/scripts/pulpcore/test_group_permissions.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "core" --min-version "3.10.dev" || exit 3
+pulp debug has-plugin --name "core" || exit 3
 
 cleanup() {
   pulp group destroy --name "cli_test_group" || true

--- a/tests/scripts/pulpcore/test_signing_service.sh
+++ b/tests/scripts/pulpcore/test_signing_service.sh
@@ -3,7 +3,7 @@
 # shellcheck source=tests/scripts/config.source
 . "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
 
-pulp debug has-plugin --name "core" --min-version 3.11 || exit 3
+pulp debug has-plugin --name "core" || exit 3
 pulp debug has-plugin --name "deb" || exit 3
 
 expect_succ pulp signing-service list

--- a/tests/scripts/pulpcore/test_worker.sh
+++ b/tests/scripts/pulpcore/test_worker.sh
@@ -12,8 +12,4 @@ expect_succ pulp worker list --not-missing
 expect_succ pulp worker list --online
 expect_succ pulp worker list --not-online
 expect_succ pulp worker list --name "resource-manager"
-
-if pulp debug has-plugin --name "core" --min-version "3.10.0"
-then
-  expect_succ pulp worker list --name-contains "resource"
-fi
+expect_succ pulp worker list --name-contains "resource"


### PR DESCRIPTION
Require pulpcore>=3.11 and drop all workarounds for older versions.
Transitive plugin requirements:
  pulp_container>=2.3

fixes #308