### PR TITLE
Make commands and options polymorphic

### DIFF
--- a/pulpcore/cli/ansible/context.py
+++ b/pulpcore/cli/ansible/context.py
@@ -24,9 +24,8 @@ class PulpAnsibleCollectionVersionContext(PulpContentContext):
     CREATE_ID = "content_ansible_collection_versions_create"
     UPLOAD_ID: ClassVar[str] = "upload_collection"
 
-    def upload(self, file: IO[bytes], body: Any) -> Any:
-        body = self.preprocess_body(body)
-        return self.pulp_ctx.call(self.UPLOAD_ID, body=body, uploads={"file": file.read()})
+    def upload(self, file: IO[bytes]) -> Any:
+        return self.pulp_ctx.call(self.UPLOAD_ID, uploads={"file": file.read()})
 
 
 class PulpAnsibleRoleContext(PulpContentContext):

--- a/pulpcore/cli/ansible/remote.py
+++ b/pulpcore/cli/ansible/remote.py
@@ -19,6 +19,8 @@ from pulpcore.cli.common.generic import (
     label_select_option,
     list_command,
     name_option,
+    pulp_group,
+    pulp_option,
     show_command,
     update_command,
 )
@@ -30,12 +32,6 @@ def _requirements_callback(
     ctx: click.Context, param: click.Parameter, value: Any
 ) -> Optional[Union[str, Any]]:
     if value:
-        if isinstance(ctx.obj, PulpAnsibleRoleRemoteContext):
-            raise click.ClickException(
-                _("Option {parameter} not valid for Role remote, see --help").format(
-                    parameter=param.name
-                )
-            )
         if param.name == "requirements_file":
             return f"{yaml.safe_load(value)}"
         elif param.name == "requirements":
@@ -43,7 +39,7 @@ def _requirements_callback(
     return value
 
 
-@click.group()
+@pulp_group()
 @click.option(
     "-t",
     "--type",
@@ -63,31 +59,36 @@ def remote(ctx: click.Context, pulp_ctx: PulpContext, remote_type: str) -> None:
         raise NotImplementedError()
 
 
+collection_context = (PulpAnsibleCollectionRemoteContext,)
 lookup_options = [href_option, name_option]
 remote_options = [
     click.option("--policy", help=_("policy to use when downloading")),
 ]
 collection_options = [
-    click.option(
+    pulp_option(
         "--requirements-file",
         callback=_requirements_callback,
         type=click.File(),
         help=_("Collections only: a Collection requirements yaml"),
+        allowed_with_contexts=collection_context,
     ),
-    click.option(
+    pulp_option(
         "--requirements",
         callback=_requirements_callback,
         help=_("Collections only: a string of a requirements yaml"),
+        allowed_with_contexts=collection_context,
     ),
-    click.option(
+    pulp_option(
         "--auth-url",
         callback=_requirements_callback,
         help=_("Collections only: URL to receive a session token"),
+        allowed_with_contexts=collection_context,
     ),
-    click.option(
+    pulp_option(
         "--token",
         callback=_requirements_callback,
         help=_("Collections only: token key use for authentication"),
+        allowed_with_contexts=collection_context,
     ),
 ]
 ansible_remote_options = remote_options + collection_options

--- a/pulpcore/cli/ansible/repository.py
+++ b/pulpcore/cli/ansible/repository.py
@@ -34,6 +34,7 @@ from pulpcore.cli.common.generic import (
     resource_option,
     retained_versions_option,
     show_command,
+    type_option,
     update_command,
     version_command,
 )
@@ -64,19 +65,6 @@ CONTENT_LIST_SCHEMA = s.Schema(
 def _content_callback(ctx: click.Context, param: click.Parameter, value: Any) -> Any:
     if value:
         ctx.obj.entity = value  # The context is set by the type parameter on the content commands
-    return value
-
-
-def _content_type_callback(ctx: click.Context, param: click.Parameter, value: Any) -> Any:
-    # This needs to run eagerly
-    pulp_ctx = ctx.find_object(PulpContext)
-    assert pulp_ctx is not None
-    if value == "collection-version":
-        ctx.obj = PulpAnsibleCollectionVersionContext(pulp_ctx)
-    elif value == "role":
-        ctx.obj = PulpAnsibleRoleContext(pulp_ctx)
-    else:
-        raise NotImplementedError()
     return value
 
 
@@ -132,15 +120,12 @@ content_options = [
         expose_value=False,
         cls=GroupOption,
     ),
-    click.option(
-        "-t",
-        "--type",
-        "type",
-        type=click.Choice(["collection-version", "role"]),
+    type_option(
+        choices={
+            "collection-version": PulpAnsibleCollectionVersionContext,
+            "role": PulpAnsibleRoleContext,
+        },
         default="collection-version",
-        expose_value=False,
-        callback=_content_type_callback,
-        is_eager=True,
     ),
     href_option,
 ]
@@ -164,15 +149,12 @@ modify_options = [
     The argument prefixed with the '@' can be the path to a JSON file with a list of objects."""
         ),
     ),
-    click.option(
-        "-t",
-        "--type",
-        "type",
-        type=click.Choice(["collection-version", "role"]),
+    type_option(
+        choices={
+            "collection-version": PulpAnsibleCollectionVersionContext,
+            "role": PulpAnsibleRoleContext,
+        },
         default="collection-version",
-        expose_value=False,
-        callback=_content_type_callback,
-        is_eager=True,
     ),
 ]
 

--- a/tests/scripts/pulp_ansible/test_content.sh
+++ b/tests/scripts/pulp_ansible/test_content.sh
@@ -7,7 +7,7 @@ pulp debug has-plugin --name "ansible" || exit 3
 
 cleanup() {
   pulp ansible repository destroy --name "cli_test_ansible_repository" || true
-  pulp orphans delete || true
+  pulp orphan cleanup || true
 }
 trap cleanup EXIT
 

--- a/tests/scripts/pulp_ansible/test_remote.sh
+++ b/tests/scripts/pulp_ansible/test_remote.sh
@@ -21,7 +21,6 @@ expect_succ pulp ansible remote -t "collection" list
 expect_succ pulp ansible remote -t "role" update --name "cli_test_ansible_role_remote" --download-concurrency "5"
 expect_succ pulp ansible remote -t "collection" update --name "cli_test_ansible_collection_remote" --download-concurrency "5"
 expect_fail pulp ansible remote -t "role" update --name "cli_test_ansible_role_remote" --requirements "collections:\n  - robertdebock.ansible_development_environment"
-test "$ERROUTPUT" = "Error: Option requirements not valid for Role remote, see --help"
 expect_succ pulp ansible remote -t "role" destroy --name "cli_test_ansible_role_remote"
 expect_succ pulp ansible remote -t "collection" destroy --name "cli_test_ansible_collection_remote"
 

--- a/tests/scripts/pulp_ansible/test_sync.sh
+++ b/tests/scripts/pulp_ansible/test_sync.sh
@@ -9,6 +9,7 @@ cleanup() {
   pulp ansible remote -t "role" destroy --name "cli_test_ansible_remote" || true
   pulp ansible remote -t "collection" destroy --name "cli_test_ansible_collection_remote" || true
   pulp ansible repository destroy --name "cli_test_ansible_repository" || true
+  pulp orphan cleanup || true
 }
 trap cleanup EXIT
 

--- a/tests/scripts/pulp_container/test_repository.sh
+++ b/tests/scripts/pulp_container/test_repository.sh
@@ -18,3 +18,6 @@ expect_succ pulp container repository show --name "cli_test_container_repo"
 test "$(echo "$OUTPUT" | jq -r '.description')" = "null"
 expect_succ pulp container repository list
 expect_succ pulp container repository destroy --name "cli_test_container_repo"
+
+expect_succ pulp container repository -t "push" --help
+test "$(echo "$OUTPUT" | grep -E "create|update|destroy|sync")" = ""


### PR DESCRIPTION
fixes: TBD

Started playing around with a different version of command/option polymorphism that is hopefully much easier to use. Have two examples; option polymorphism for ansible remote options, and command polymorphism for container repository commands.  The poly options is pretty simplistic, but the poly commands require a new `type_callback` that is eagerly ran so that it properly updates in the help menu.

WIP, so tell me what you think of these methods.