### PR TITLE
Add remote option to python distribution commands

### DIFF
--- a/CHANGES/417.feature
+++ b/CHANGES/417.feature
@@ -1,0 +1,1 @@
+Added remote option for Python distributions.

--- a/pulpcore/cli/python/distribution.py
+++ b/pulpcore/cli/python/distribution.py
@@ -18,7 +18,11 @@ from pulpcore.cli.common.generic import (
     show_command,
     update_command,
 )
-from pulpcore.cli.python.context import PulpPythonDistributionContext, PulpPythonRepositoryContext
+from pulpcore.cli.python.context import (
+    PulpPythonDistributionContext,
+    PulpPythonRemoteContext,
+    PulpPythonRepositoryContext,
+)
 
 _ = gettext.gettext
 
@@ -33,6 +37,14 @@ repository_option = resource_option(
         " When set, this will unset the 'publication'."
         " Specified as '[[<plugin>:]<type>:]<name>' or as href."
     ),
+)
+
+remote_option = resource_option(
+    "--remote",
+    default_plugin="python",
+    default_type="python",
+    context_table={"python:python": PulpPythonRemoteContext},
+    needs_plugins=[PluginRequirement("python", "3.6.0.dev")],
 )
 
 
@@ -69,6 +81,7 @@ update_options = [
         needs_plugins=[PluginRequirement("python", "3.4.0.dev")],
         default=None,
     ),
+    remote_option,
 ]
 create_options = update_options + [click.option("--name", required=True)]
 

--- a/tests/scripts/pulp_python/test_distribution.sh
+++ b/tests/scripts/pulp_python/test_distribution.sh
@@ -38,14 +38,22 @@ expect_succ pulp python distribution update \
   --base-path "cli_test_python_distro" \
   --publication "$PUBLICATION_HREF"
 
-expect_succ curl "$curl_opt" --head --fail "$PULP_BASE_URL/pulp/content/cli_test_python_distro/simple/"
-
-if [ "$(pulp debug has-plugin --name "python" --min-version "3.4.0.dev")" = "true" ]
+if pulp debug has-plugin --name "python" --min-version "3.4.0.dev"
 then
+  expect_succ curl "$curl_opt" --head --fail "$PULP_BASE_URL/pypi/cli_test_python_distro/simple/"
   expect_succ pulp python distribution update \
   --name "cli_test_python_distro" \
   --repository "cli_test_python_repository" \
   --block-uploads
+else
+  expect_succ curl "$curl_opt" --head --fail "$PULP_BASE_URL/pulp/content/cli_test_python_distro/simple/"
+fi
+
+if pulp debug has-plugin --name "python" --min-version "3.6.0.dev"
+then
+  expect_succ pulp python distribution update \
+  --name "cli_test_python_distro" \
+  --remote "cli_test_python_remote"
 fi
 
 expect_succ pulp python distribution destroy --name "cli_test_python_distro"


### PR DESCRIPTION
fixes: #417
Required PR: https://github.com/pulp/pulp_python/pull/384