### PR TITLE
Refactor plugin loading

### DIFF
--- a/pulp_cli/__init__.py
+++ b/pulp_cli/__init__.py
@@ -1,1 +1,20 @@
-from pulpcore.cli.common import main  # noqa: F401
+from types import ModuleType
+from typing import Any, Dict
+
+import click
+import pkg_resources
+
+
+def main() -> Any:
+    ##############################################################################
+    # Load plugins
+    # https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata
+    discovered_plugins: Dict[str, ModuleType] = {
+        entry_point.name: entry_point.load()
+        for entry_point in pkg_resources.iter_entry_points("pulp_cli.plugins")
+    }
+    _main: click.Group = discovered_plugins["common"].main
+    for plugin in discovered_plugins.values():
+        if hasattr(plugin, "mount"):
+            plugin.mount(_main, discovered_plugins=discovered_plugins)
+    return _main()

--- a/pulpcore/cli/ansible/__init__.py
+++ b/pulpcore/cli/ansible/__init__.py
@@ -1,22 +1,28 @@
+from typing import Any
+
+import click
+
 from pulpcore.cli.ansible.content import content
 from pulpcore.cli.ansible.distribution import distribution
 from pulpcore.cli.ansible.remote import remote
 from pulpcore.cli.ansible.repository import repository
-from pulpcore.cli.common import main
 from pulpcore.cli.common.context import PluginRequirement, PulpContext, pass_pulp_context
+from pulpcore.cli.common.generic import pulp_group
 from pulpcore.cli.common.i18n import get_translation
 
 translation = get_translation(__name__)
 _ = translation.gettext
 
 
-@main.group()
+@pulp_group()
 @pass_pulp_context
 def ansible(pulp_ctx: PulpContext) -> None:
     pulp_ctx.needs_plugin(PluginRequirement("ansible", min="0.7"))
 
 
-ansible.add_command(repository)
-ansible.add_command(remote)
-ansible.add_command(distribution)
-ansible.add_command(content)
+def mount(main: click.Group, **kwargs: Any) -> None:
+    ansible.add_command(repository)
+    ansible.add_command(remote)
+    ansible.add_command(distribution)
+    ansible.add_command(content)
+    main.add_command(ansible)

--- a/pulpcore/cli/common/__init__.py
+++ b/pulpcore/cli/common/__init__.py
@@ -3,7 +3,6 @@ import sys
 from typing import Any, Optional
 
 import click
-import pkg_resources
 import toml
 
 try:
@@ -160,12 +159,3 @@ if HAS_CLICK_SHELL:
             intro="Starting Pulp3 interactive shell...",
             hist_file=os.path.join(click.utils.get_app_dir("pulp"), "cli-history"),
         ).cmdloop()
-
-
-##############################################################################
-# Load plugins
-# https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata
-discovered_plugins = {
-    entry_point.name: entry_point.load()
-    for entry_point in pkg_resources.iter_entry_points("pulp_cli.plugins")
-}

--- a/pulpcore/cli/container/__init__.py
+++ b/pulpcore/cli/container/__init__.py
@@ -1,5 +1,9 @@
-from pulpcore.cli.common import main
+from typing import Any
+
+import click
+
 from pulpcore.cli.common.context import PluginRequirement, PulpContext, pass_pulp_context
+from pulpcore.cli.common.generic import pulp_group
 from pulpcore.cli.common.i18n import get_translation
 from pulpcore.cli.container.content import content
 from pulpcore.cli.container.distribution import distribution
@@ -11,14 +15,16 @@ translation = get_translation(__name__)
 _ = translation.gettext
 
 
-@main.group()
+@pulp_group()
 @pass_pulp_context
 def container(pulp_ctx: PulpContext) -> None:
     pulp_ctx.needs_plugin(PluginRequirement("container", min="2.3"))
 
 
-container.add_command(repository)
-container.add_command(remote)
-container.add_command(namespace)
-container.add_command(distribution)
-container.add_command(content)
+def mount(main: click.Group, **kwargs: Any) -> None:
+    container.add_command(repository)
+    container.add_command(remote)
+    container.add_command(namespace)
+    container.add_command(distribution)
+    container.add_command(content)
+    main.add_command(container)

--- a/pulpcore/cli/core/__init__.py
+++ b/pulpcore/cli/core/__init__.py
@@ -1,4 +1,7 @@
-from pulpcore.cli.common import main
+from typing import Any
+
+import click
+
 from pulpcore.cli.core.access_policy import access_policy
 from pulpcore.cli.core.artifact import artifact
 from pulpcore.cli.core.content import content
@@ -19,23 +22,24 @@ from pulpcore.cli.core.task_group import task_group
 from pulpcore.cli.core.user import user
 from pulpcore.cli.core.worker import worker
 
-# Register commands with cli
-main.add_command(access_policy)
-main.add_command(artifact)
-main.add_command(content)
-main.add_command(export)
-main.add_command(exporter)
-main.add_command(group)
-main.add_command(content_guard)
-main.add_command(importer)
-main.add_command(orphan)
-main.add_command(orphans)  # This one is deprecated
-main.add_command(repository)
-main.add_command(role)
-main.add_command(show)
-main.add_command(signing_service)
-main.add_command(status)
-main.add_command(task)
-main.add_command(task_group)
-main.add_command(user)
-main.add_command(worker)
+
+def mount(main: click.Group, **kwargs: Any) -> None:
+    main.add_command(access_policy)
+    main.add_command(artifact)
+    main.add_command(content)
+    main.add_command(export)
+    main.add_command(exporter)
+    main.add_command(group)
+    main.add_command(content_guard)
+    main.add_command(importer)
+    main.add_command(orphan)
+    main.add_command(orphans)  # This one is deprecated
+    main.add_command(repository)
+    main.add_command(role)
+    main.add_command(show)
+    main.add_command(signing_service)
+    main.add_command(status)
+    main.add_command(task)
+    main.add_command(task_group)
+    main.add_command(user)
+    main.add_command(worker)

--- a/pulpcore/cli/file/__init__.py
+++ b/pulpcore/cli/file/__init__.py
@@ -1,5 +1,9 @@
-from pulpcore.cli.common import main
+from typing import Any
+
+import click
+
 from pulpcore.cli.common.context import PluginRequirement, PulpContext, pass_pulp_context
+from pulpcore.cli.common.generic import pulp_group
 from pulpcore.cli.common.i18n import get_translation
 from pulpcore.cli.file.acs import acs
 from pulpcore.cli.file.content import content
@@ -12,15 +16,17 @@ translation = get_translation(__name__)
 _ = translation.gettext
 
 
-@main.group(name="file")
+@pulp_group(name="file")
 @pass_pulp_context
 def file_group(pulp_ctx: PulpContext) -> None:
     pulp_ctx.needs_plugin(PluginRequirement("file", min="1.6"))
 
 
-file_group.add_command(repository)
-file_group.add_command(remote)
-file_group.add_command(publication)
-file_group.add_command(distribution)
-file_group.add_command(content)
-file_group.add_command(acs)
+def mount(main: click.Group, **kwargs: Any) -> None:
+    file_group.add_command(repository)
+    file_group.add_command(remote)
+    file_group.add_command(publication)
+    file_group.add_command(distribution)
+    file_group.add_command(content)
+    file_group.add_command(acs)
+    main.add_command(file_group)

--- a/pulpcore/cli/migration/__init__.py
+++ b/pulpcore/cli/migration/__init__.py
@@ -1,14 +1,20 @@
-from pulpcore.cli.common import main
+from typing import Any
+
+import click
+
 from pulpcore.cli.common.context import PluginRequirement, PulpContext, pass_pulp_context
+from pulpcore.cli.common.generic import pulp_group
 from pulpcore.cli.migration.plan import plan
 from pulpcore.cli.migration.pulp2 import pulp2
 
 
-@main.group()
+@pulp_group()
 @pass_pulp_context
 def migration(pulp_ctx: PulpContext) -> None:
     pulp_ctx.needs_plugin(PluginRequirement("pulp_2to3_migration"))
 
 
-migration.add_command(plan)
-migration.add_command(pulp2)
+def mount(main: click.Group, **kwargs: Any) -> None:
+    migration.add_command(plan)
+    migration.add_command(pulp2)
+    main.add_command(migration)

--- a/pulpcore/cli/python/__init__.py
+++ b/pulpcore/cli/python/__init__.py
@@ -1,5 +1,9 @@
-from pulpcore.cli.common import main
+from typing import Any
+
+import click
+
 from pulpcore.cli.common.context import PluginRequirement, PulpContext, pass_pulp_context
+from pulpcore.cli.common.generic import pulp_group
 from pulpcore.cli.python.content import content
 from pulpcore.cli.python.distribution import distribution
 from pulpcore.cli.python.publication import publication
@@ -7,14 +11,16 @@ from pulpcore.cli.python.remote import remote
 from pulpcore.cli.python.repository import repository
 
 
-@main.group(name="python")
+@pulp_group(name="python")
 @pass_pulp_context
 def python_group(pulp_ctx: PulpContext) -> None:
     pulp_ctx.needs_plugin(PluginRequirement("python", min="3.1"))
 
 
-python_group.add_command(repository)
-python_group.add_command(remote)
-python_group.add_command(publication)
-python_group.add_command(distribution)
-python_group.add_command(content)
+def mount(main: click.Group, **kwargs: Any) -> None:
+    python_group.add_command(repository)
+    python_group.add_command(remote)
+    python_group.add_command(publication)
+    python_group.add_command(distribution)
+    python_group.add_command(content)
+    main.add_command(python_group)

--- a/pulpcore/cli/rpm/__init__.py
+++ b/pulpcore/cli/rpm/__init__.py
@@ -1,5 +1,9 @@
-from pulpcore.cli.common import main
+from typing import Any
+
+import click
+
 from pulpcore.cli.common.context import PluginRequirement, PulpContext, pass_pulp_context
+from pulpcore.cli.common.generic import pulp_group
 from pulpcore.cli.common.i18n import get_translation
 from pulpcore.cli.rpm.acs import acs
 from pulpcore.cli.rpm.comps import comps_upload
@@ -13,16 +17,18 @@ translation = get_translation(__name__)
 _ = translation.gettext
 
 
-@main.group()
+@pulp_group()
 @pass_pulp_context
 def rpm(pulp_ctx: PulpContext) -> None:
     pulp_ctx.needs_plugin(PluginRequirement("rpm", min="3.9"))
 
 
-rpm.add_command(repository)
-rpm.add_command(remote)
-rpm.add_command(publication)
-rpm.add_command(distribution)
-rpm.add_command(content)
-rpm.add_command(acs)
-rpm.add_command(comps_upload)
+def mount(main: click.Group, **kwargs: Any) -> None:
+    rpm.add_command(repository)
+    rpm.add_command(remote)
+    rpm.add_command(publication)
+    rpm.add_command(distribution)
+    rpm.add_command(content)
+    rpm.add_command(acs)
+    rpm.add_command(comps_upload)
+    main.add_command(rpm)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ markers = [
 [tool.mypy]
 strict = true
 show_error_codes = true
-files = "pulpcore/**/*.py"
+files = "pulpcore/**/*.py, pulp_cli/**/*.py"
 namespace_packages = true
 explicit_package_bases = true
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup
 try:
     from setuptools import find_namespace_packages
 
-    main_entrypoint = "pulp=pulpcore.cli.common:main"
     plugin_packages = find_namespace_packages(
         include=["pulpcore.cli.*"], exclude=["pulpcore.cli.*.*"]
     )
@@ -13,17 +12,12 @@ except ImportError:
     # see https://github.com/pulp/pulp-cli/issues/248
     from setuptools import find_packages
 
-    main_entrypoint = "pulp=pulp_cli:main"
     plugins = find_packages(where="pulpcore/cli")
     plugin_packages = [f"pulpcore.cli.{plugin}" for plugin in plugins]
 
 extra_packages = ["pulp_cli", "pytest_pulp_cli"]
 
-plugin_entry_points = [
-    (package.rsplit(".", 1)[-1], package)
-    for package in plugin_packages
-    if package != "pulpcore.cli.common"
-]
+plugin_entry_points = [(package.rsplit(".", 1)[-1], package) for package in plugin_packages]
 
 long_description = ""
 with open("README.md") as readme:
@@ -58,7 +52,7 @@ setup(
         "shell": ["click-shell~=2.1"],
     },
     entry_points={
-        "console_scripts": [main_entrypoint],
+        "console_scripts": ["pulp=pulp_cli:main"],
         "pulp_cli.plugins": [f"{name}={module}" for name, module in plugin_entry_points],
     },
     license="GPLv2+",


### PR DESCRIPTION
Deferred the plugin loading to the entry point to prevent some chances
of circular imports. Loaded plugins should provide a `mount` method to
register their commands to the main group.