### PR TITLE
Add CA and proxy information from environment

### DIFF
--- a/CHANGES/95.feature
+++ b/CHANGES/95.feature
@@ -1,0 +1,2 @@
+Allow path to certificate bundle to be specified via `PULP_CA_BUNDLE`, `REQUESTS_CA_BUNDLE` or `CURL_CA_BUNDLE` environment variables.
+Use proxy settings from environment.

--- a/docs/advanced_features.md
+++ b/docs/advanced_features.md
@@ -1,5 +1,10 @@
 # Advanced features
 
+## Custom CA bundle
+
+You can specify a custom CA bundle for the connection to a Pulp server by providing a path in one of the following environment variables (ordered by precedence):
+`PULP_CA_BUNDLE` ,`REQUESTS_CA_BUNDLE` `CURL_CA_BUNDLE`
+
 ## Shell Completion
 
 The CLI uses the click package which supports shell completion.


### PR DESCRIPTION
This allows to specify a custom CA bundle in REQUEST_CA_BUNDLE or
CURL_CA_BUNDLE. Also proxy information from the environment will be
honored.

fixes #95