### PR TITLE
Fix mypy linting

### DIFF
--- a/pulpcore/cli/common/openapi.py
+++ b/pulpcore/cli/common/openapi.py
@@ -37,7 +37,8 @@ class OpenAPI:
         user_agent: Optional[str] = None,
     ):
         if not validate_certs:
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+            # types-urllib3 does not cover that function
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)  # type:ignore
 
         self.debug_callback: Callable[[int, str], Any] = debug_callback or (lambda i, x: None)
         self.base_url: str = base_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,6 @@ explicit_package_bases = true
 
 [[tool.mypy.overrides]]
 module = [
-  "urllib3.*",
   "click_shell.*",
   "schema.*",
 ]


### PR DESCRIPTION
A new version of types-requests seem to depend on the incomplete
types-urllib3. So we need to ignore the offending call directly.

[noissue]