### PR TITLE
Fix missing help text for ACS path option

### DIFF
--- a/CHANGES/446.bugfix
+++ b/CHANGES/446.bugfix
@@ -1,0 +1,1 @@
+Fixed missing help text on path option for ACS create commands.

--- a/pulpcore/cli/file/acs.py
+++ b/pulpcore/cli/file/acs.py
@@ -102,11 +102,6 @@ remote_option = resource_option(
     href_pattern=PulpRemoteContext.HREF_PATTERN,
     help=_("Remote to attach to ACS in the form '[[<plugin>:]<resource_type>:]<name>' or by href."),
 )
-path_option = click.option(
-    "--path",
-    "paths",
-    multiple=True,
-)
 lookup_options = [href_option, name_option]
 update_options = [remote_option]
 create_options = update_options + [click.option("--name", required=True), path_option]

--- a/pulpcore/cli/rpm/acs.py
+++ b/pulpcore/cli/rpm/acs.py
@@ -102,11 +102,6 @@ remote_option = resource_option(
     href_pattern=PulpRemoteContext.HREF_PATTERN,
     help=_("Remote to attach to ACS in the form '[[<plugin>:]<resource_type>:]<name>' or by href."),
 )
-path_option = click.option(
-    "--path",
-    "paths",
-    multiple=True,
-)
 lookup_options = [href_option, name_option]
 update_options = [remote_option]
 create_options = update_options + [click.option("--name", required=True), path_option]


### PR DESCRIPTION
Fixed bug where path_option gets redefined without help text.

fixes #446