### PR TITLE
Fix error reporting on tasks

### DIFF
--- a/CHANGES/464.bugfix
+++ b/CHANGES/464.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in reporting the failure of a task if the reason was not an exception in the task code.

--- a/pulpcore/cli/common/context.py
+++ b/pulpcore/cli/common/context.py
@@ -183,7 +183,8 @@ class PulpContext:
         elif task["state"] == "failed":
             raise click.ClickException(
                 _("Task {task_href} failed: '{description}'").format(
-                    task_href=task_href, description=task["error"]["description"]
+                    task_href=task_href,
+                    description=task["error"].get("description") or task["error"].get("reason"),
                 )
             )
         elif task["state"] == "canceled":


### PR DESCRIPTION
If a task fails not due to an Exception, we do not get the description field.
Try reason filed instead.