### PR TITLE
Add ansible signature commands

### DIFF
--- a/.ci/container_setup.d/10-install-signing-service.sh
+++ b/.ci/container_setup.d/10-install-signing-service.sh
@@ -2,14 +2,32 @@
 
 set -eu
 
-if pulp --format none --refresh-api --base-url "http://localhost:8080" ${PULP_API_ROOT:+--api-root "${PULP_API_ROOT}"} --username "admin" --password "password" debug has-plugin --name "deb"
+pulp --refresh-api --base-url "http://localhost:8080" ${PULP_API_ROOT:+--api-root "${PULP_API_ROOT}"} --username "admin" --password "password" debug has-plugin --name "deb" && HAS_DEB=true || HAS_DEB=""
+pulp --base-url "http://localhost:8080" ${PULP_API_ROOT:+--api-root "${PULP_API_ROOT}"} --username "admin" --password "password" debug has-plugin --name "ansible" && HAS_ANSIBLE=true || HAS_ANSIBLE=""
+if [ "$HAS_DEB" ] || [ "$HAS_ANSIBLE" ]
 then
-  echo "Setup a signing service"
-  "${CONTAINER_RUNTIME}" exec -i "pulp-ephemeral" bash -c "cat > /root/sign_deb_release.sh" < "${BASEPATH}/../tests/assets/sign_deb_release.sh"
-  "${CONTAINER_RUNTIME}" exec -i "pulp-ephemeral" bash -c "cat > /tmp/setup_signing_service.py" < "${BASEPATH}/../tests/assets/setup_signing_service.py"
+  echo "Setup the signing services"
+  # Setup key on the Pulp container
   curl -L https://github.com/pulp/pulp-fixtures/raw/master/common/GPG-KEY-pulp-qe | "${CONTAINER_RUNTIME}" exec -i "pulp-ephemeral" bash -c "cat > /tmp/GPG-KEY-pulp-qe"
   curl -L https://github.com/pulp/pulp-fixtures/raw/master/common/GPG-PRIVATE-KEY-pulp-qe | "${CONTAINER_RUNTIME}" exec -i "pulp-ephemeral" gpg --import
   echo "6EDF301256480B9B801EBA3D05A5E6DA269D9D98:6:" | "${CONTAINER_RUNTIME}" exec -i "pulp-ephemeral" gpg --import-ownertrust
-  "${CONTAINER_RUNTIME}" exec "pulp-ephemeral" chmod a+x /root/sign_deb_release.sh /tmp/setup_signing_service.py
-  "${CONTAINER_RUNTIME}" exec "pulp-ephemeral" /tmp/setup_signing_service.py /root/sign_deb_release.sh /tmp/GPG-KEY-pulp-qe
+  # Setup key on the test machine
+  curl -L https://github.com/pulp/pulp-fixtures/raw/master/common/GPG-KEY-pulp-qe | cat > /tmp/GPG-KEY-pulp-qe
+  curl -L https://github.com/pulp/pulp-fixtures/raw/master/common/GPG-PRIVATE-KEY-pulp-qe | gpg --import
+  echo "6EDF301256480B9B801EBA3D05A5E6DA269D9D98:6:" | gpg --import-ownertrust
+  if [ "$HAS_DEB" ]
+  then
+    echo "Setup deb release signing service"
+    "${CONTAINER_RUNTIME}" exec -i "pulp-ephemeral" bash -c "cat > /root/sign_deb_release.sh" < "${BASEPATH}/../tests/assets/sign_deb_release.sh"
+    "${CONTAINER_RUNTIME}" exec "pulp-ephemeral" chmod a+x /root/sign_deb_release.sh
+    "${CONTAINER_RUNTIME}" exec "pulp-ephemeral" bash -c "pulpcore-manager add-signing-service --class deb:AptReleaseSigningService sign_deb_release /root/sign_deb_release.sh 'Pulp QE'"
+  fi
+  if [ "$HAS_ANSIBLE" ]
+  then
+    echo "Setup ansible signing service"
+    "${CONTAINER_RUNTIME}" exec -i "pulp-ephemeral" bash -c "cat > /root/sign_detached.sh" < "${BASEPATH}/../tests/assets/sign_detached.sh"
+    "${CONTAINER_RUNTIME}" exec "pulp-ephemeral" chmod a+x /root/sign_detached.sh
+    "${CONTAINER_RUNTIME}" exec "pulp-ephemeral" bash -c "pulpcore-manager add-signing-service --class core:AsciiArmoredDetachedSigningService sign_ansible /root/sign_detached.sh 'Pulp QE'"
+  fi
 fi
+

--- a/CHANGES/481.feature
+++ b/CHANGES/481.feature
@@ -1,0 +1,1 @@
+Added ansible signature command.

--- a/CHANGES/484.feature
+++ b/CHANGES/484.feature
@@ -1,0 +1,1 @@
+Added ansible signature list/read/upload commands.

--- a/docs/supported_workflows.md
+++ b/docs/supported_workflows.md
@@ -52,10 +52,10 @@ The CLI currently supports the following workflows:
 The CLI currently supports the following operations on these `pulp_ansible` objects
 (C = Create, R = Read, U = Update, D = Delete):
 
-* Role/Collection Version Content - **CR**
+* Role/Collection Version/Signature Content - **CR**
 * Ansible Distributions - **CRUD**
 * Role/Collection Version Remotes - **CRUD**
-* Ansible Repositories - **CRUD, Modify, Sync**
+* Ansible Repositories - **CRUD, Modify, Sync, Sign**
 
 
 ## pulp_container

--- a/pulpcore/cli/ansible/context.py
+++ b/pulpcore/cli/ansible/context.py
@@ -34,6 +34,13 @@ class PulpAnsibleRoleContext(PulpContentContext):
     ID_PREFIX = "content_ansible_roles"
 
 
+class PulpAnsibleCollectionVersionSignatureContext(PulpContentContext):
+    ENTITY = _("ansible collection version signature")
+    ENTITIES = _("ansible collection version signatures")
+    HREF = _("ansible_collection_version_signature_href")
+    ID_PREFIX = "content_ansible_collection_signatures"
+
+
 class PulpAnsibleDistributionContext(PulpEntityContext):
     ENTITY = _("ansible distribution")
     ENTITIES = _("ansible distributions")

--- a/tests/assets/sign_detached.sh
+++ b/tests/assets/sign_detached.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+FILE_PATH=$1
+SIGNATURE_PATH="$1.asc"
+: "${PULP_SIGNING_KEY_FINGERPRINT:="Pulp QE"}"
+
+# Create a detached signature
+gpg --quiet --batch --homedir ~/.gnupg/ --detach-sign --default-key "${PULP_SIGNING_KEY_FINGERPRINT}" \
+   --armor --output "${SIGNATURE_PATH}" "${FILE_PATH}"
+
+# Check the exit status
+STATUS=$?
+if [[ ${STATUS} -eq 0 ]]; then
+   echo "{\"file\": \"${FILE_PATH}\", \"signature\": \"${SIGNATURE_PATH}\"}"
+else
+   exit ${STATUS}
+fi

--- a/tests/scripts/pulp_ansible/test_content.sh
+++ b/tests/scripts/pulp_ansible/test_content.sh
@@ -35,6 +35,20 @@ test "$(echo "$OUTPUT" | jq -r length)" -eq "1"
 content2_href="$(echo "$OUTPUT" | jq -r .[0].pulp_href)"
 expect_succ pulp ansible content --type "role" show --href "$content2_href"
 
+# Test ansible signature upload
+if pulp debug has-plugin --name "ansible" --min-version "0.13.0.dev"
+then
+  expect_succ pulp ansible content --type "signature" list
+  tar --extract --file="ansible-posix-1.3.0.tar.gz" "MANIFEST.json"
+  collection_path="$(realpath 'MANIFEST.json')"
+  signature_path="$("$(dirname "$(dirname "$(dirname "$(realpath "$0")")")")"/assets/sign_detached.sh "$collection_path" | jq -r .signature)"
+  expect_succ pulp ansible content --type "signature" upload --file "$signature_path" --collection "$content_href"
+  expect_succ pulp ansible content --type "signature" list --collection "$content_href" --pubkey-fingerprint "6EDF301256480B9B801EBA3D05A5E6DA269D9D98"
+  test "$(echo "$OUTPUT" | jq -r length)" -eq "1"
+  content3_href="$(echo "$OUTPUT" | jq -r .[0].pulp_href)"
+  expect_succ pulp ansible content --type "signature" show --href "$content3_href"
+fi
+
 # New content commands
 expect_succ pulp ansible repository create --name "cli_test_ansible_repository"
 expect_succ pulp ansible repository content add --repository "cli_test_ansible_repository" --name "posix" --namespace "ansible" --version "1.3.0"

--- a/tests/scripts/pulp_ansible/test_sign.sh
+++ b/tests/scripts/pulp_ansible/test_sign.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# shellcheck source=tests/scripts/config.source
+. "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
+
+pulp debug has-plugin --name "ansible" --min-version "0.12.0" || exit 3
+
+cleanup() {
+  pulp ansible remote -t "collection" destroy --name "cli_test_ansible_collection_remote" || true
+  pulp ansible repository destroy --name "cli_test_ansible_repository" || true
+  pulp orphan cleanup || true
+}
+trap cleanup EXIT
+
+# Prepare
+expect_succ pulp ansible remote -t "collection" create --name "cli_test_ansible_collection_remote" \
+--url "$ANSIBLE_COLLECTION_REMOTE_URL" --requirements "collections:\n  - robertdebock.ansible_development_environment"
+expect_succ pulp ansible repository create --name "cli_test_ansible_repository"
+expect_succ pulp ansible repository sync --name "cli_test_ansible_repository" --remote "cli_test_ansible_collection_remote"
+
+# Test sign
+expect_succ pulp ansible repository sign --name "cli_test_ansible_repository" --signing-service "sign_ansible"
+
+# Verify sign
+expect_succ pulp ansible repository version list --repository "cli_test_ansible_repository"
+test "$(echo "$OUTPUT" | jq -r length)" -eq 3
+expect_succ pulp ansible repository version show --repository "cli_test_ansible_repository" --version 2
+test "$(echo "$OUTPUT" | jq -r '.content_summary.present."ansible.collection_signature".count')" -gt 0


### PR DESCRIPTION
[noissue]

Implemented the signature task command. Should I just put the collection signature list/read/create commands under the ansible content commands or create its own sub-group?

TODO:

- [x] Add issues
- [x] Signature list/read/create
- [x] Tests
- [x] Update capabilities doc