### PR TITLE
add --optimize and --sync-policy options to rpm repo sync

### DIFF
--- a/pulpcore/cli/rpm/repository.py
+++ b/pulpcore/cli/rpm/repository.py
@@ -166,15 +166,18 @@ repository.add_command(
 @remote_option
 @click.option("--mirror/--no-mirror", default=None,
               help="DEPRECATED: If True, sync_policy will default to 'mirror_complete' instead of 'additive'.")
-@click.option("--optimize/--no-optimize", default=None,
-              help="Whether or not to optimize sync.")
+@pulp_option("--optimize/--no-optimize", default=None,
+              help="Whether or not to optimize sync.",
+              needs_plugins=[PluginRequirement("rpm", "3.3.0")],
+)
 @click.option(
     "--skip-type", "skip_types", multiple=True, type=click.Choice(SKIP_TYPES, case_sensitive=False),
     help="List of content types to skip during sync.",
 )
-@click.option(
+@pulp_option(
     "--sync-policy", "sync_policy", type=click.Choice(SYNC_TYPES, case_sensitive=False),
-    help="Modifies how the sync is performed. 'mirror_complete' will clone the original metadata and create an automatic publication from it, but comes with some limitations and does not work for certain repositories. 'mirror_content_only' will change the repository contents to match the remote but the metadata will be regenerated and will not be bit-for-bit identical. 'additive' will retain the existing contents of the repository and add the contents of the repository being synced."
+    help="Modifies how the sync is performed. 'mirror_complete' will clone the original metadata and create an automatic publication from it, but comes with some limitations and does not work for certain repositories. 'mirror_content_only' will change the repository contents to match the remote but the metadata will be regenerated and will not be bit-for-bit identical. 'additive' will retain the existing contents of the repository and add the contents of the repository being synced.",
+    needs_plugins=[PluginRequirement("rpm", "3.16.0")],
 )
 @pass_repository_context
 def sync(


### PR DESCRIPTION
The rpm repository sync function added a sync_policy option in 3.16.0.  This commit adds that as --sync-policy in addition to adding an --optimize switch which was missing.  