### PR TITLE
Require click>=8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_data={"": ["py.typed", "locale/*/LC_MESSAGES/*.mo"]},
     python_requires=">=3.6",
     install_requires=[
-        "click>=7.1.2,<9.0.0",
+        "click>=8.0.0,<9.0.0",
         "packaging",
         "PyYAML~=5.3",
         "schema==0.7.5",


### PR DESCRIPTION
Version 7.1.2 of click lacks decorators.FC, resulting in `ImportError: cannot import name 'FC'` if pulp-cli is installed using pip with click 7.1.2 already installed.

[noissue]