### PR TITLE
Fix PARTIAL_UPDATE_ID workaround

### DIFF
--- a/CHANGES/529.bugfix
+++ b/CHANGES/529.bugfix
@@ -1,0 +1,1 @@
+Fixed the heuristics for the `PARTIAL_UPDATE_ID` workaround.

--- a/pulpcore/cli/common/context.py
+++ b/pulpcore/cli/common/context.py
@@ -519,7 +519,7 @@ class PulpEntityContext:
         non_blocking: bool = False,
     ) -> Any:
         # Workaround for plugins that do not have ID_PREFIX in place
-        if not hasattr(self, "ID_PREFIX") and not hasattr(self, "PARTIAL_UPDATE_ID"):
+        if hasattr(self, "UPDATE_ID") and not hasattr(self, "PARTIAL_UPDATE_ID"):
             self.PARTIAL_UPDATE_ID = getattr(self, "UPDATE_ID")
         # ----------------------------------------------------------
         _parameters = {self.HREF: href or self.pulp_href}

--- a/pulpcore/cli/common/openapi.py
+++ b/pulpcore/cli/common/openapi.py
@@ -38,7 +38,7 @@ class OpenAPI:
     ):
         if not validate_certs:
             # types-urllib3 does not cover that function
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)  # type:ignore
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
         self.debug_callback: Callable[[int, str], Any] = debug_callback or (lambda i, x: None)
         self.base_url: str = base_url


### PR DESCRIPTION
Adding ID_PREFIX to the base context models broke the heuristics of the
workaround in place for translating PARTIAL_UPDATE_ID into UPDATE_ID.

fixes #529