### PR TITLE
Fix config file loading due to lack of permissions

### DIFF
--- a/CHANGES/509.bugfix
+++ b/CHANGES/509.bugfix
@@ -1,0 +1,2 @@
+Fixed bug, where the failure to load config file due to the lack of file permissions lead to a crash.
+Now those files are simply ignored.

--- a/pulpcore/cli/common/__init__.py
+++ b/pulpcore/cli/common/__init__.py
@@ -55,7 +55,7 @@ def _config_callback(ctx: click.Context, param: Any, value: Optional[str]) -> No
                             config[key].update(new_config[key])
                         else:
                             config[key] = new_config[key]
-                except FileNotFoundError:
+                except (FileNotFoundError, PermissionError):
                     pass
         profile: str = "cli"
         if PROFILE_KEY in ctx.meta:


### PR DESCRIPTION
Config files that cannot be accessed due to the lack of permissions are
now simply ignored.

fixes #509

Co-Authored-By: Matthias Dellweg <dellweg@redhat.com>