### PR TITLE
Rearrange the removal of remotes

### DIFF
--- a/tests/scripts/pulp_container/test_content.sh
+++ b/tests/scripts/pulp_container/test_content.sh
@@ -6,8 +6,8 @@
 pulp debug has-plugin --name "container" || exit 3
 
 cleanup() {
-  pulp container remote destroy --name "cli_test_container_remote" || true
   pulp container repository destroy --name "cli_test_container_repository" || true
+  pulp container remote destroy --name "cli_test_container_remote" || true
   pulp orphan cleanup || true
 }
 trap cleanup EXIT

--- a/tests/scripts/pulp_container/test_copy.sh
+++ b/tests/scripts/pulp_container/test_copy.sh
@@ -6,9 +6,9 @@
 pulp debug has-plugin --name "container" || exit 3
 
 cleanup() {
-  pulp container remote destroy --name "cli_test_container_remote" || true
   pulp container repository destroy --name "cli_test_source_container_repository" || true
   pulp container repository destroy --name "cli_test_dest_container_repository" || true
+  pulp container remote destroy --name "cli_test_container_remote" || true
   pulp orphan cleanup || true
 }
 trap cleanup EXIT

--- a/tests/scripts/pulp_container/test_sync.sh
+++ b/tests/scripts/pulp_container/test_sync.sh
@@ -6,8 +6,8 @@
 pulp debug has-plugin --name "container" || exit 3
 
 cleanup() {
-  pulp container remote destroy --name "cli_test_container_remote" || true
   pulp container repository destroy --name "cli_test_container_repository" || true
+  pulp container remote destroy --name "cli_test_container_remote" || true
 }
 trap cleanup EXIT
 

--- a/tests/scripts/pulp_file/test_acs.sh
+++ b/tests/scripts/pulp_file/test_acs.sh
@@ -10,8 +10,8 @@ acs="cli_test_acs"
 
 cleanup() {
   pulp file acs destroy --name $acs || true
-  pulp file remote destroy --name $acs_remote || true
   pulp file repository destroy --name "cli-repo-manifest-only" || true
+  pulp file remote destroy --name $acs_remote || true
   pulp file remote destroy --name "cli-remote-manifest-only" || true
 }
 trap cleanup EXIT

--- a/tests/scripts/pulp_file/test_distribution.sh
+++ b/tests/scripts/pulp_file/test_distribution.sh
@@ -6,8 +6,8 @@
 pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
-  pulp file remote destroy --name "cli_test_file_remote" || true
   pulp file repository destroy --name "cli_test_file_repository" || true
+  pulp file remote destroy --name "cli_test_file_remote" || true
   pulp file distribution destroy --name "cli_test_file_distro" || true
 }
 trap cleanup EXIT

--- a/tests/scripts/pulp_file/test_publication.sh
+++ b/tests/scripts/pulp_file/test_publication.sh
@@ -6,8 +6,8 @@
 pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
-  pulp file remote destroy --name "cli_test_file_remote" || true
   pulp file repository destroy --name "cli_test_file_repository" || true
+  pulp file remote destroy --name "cli_test_file_remote" || true
 }
 trap cleanup EXIT
 

--- a/tests/scripts/pulp_file/test_sync.sh
+++ b/tests/scripts/pulp_file/test_sync.sh
@@ -9,10 +9,10 @@ autopublish_repo="cli_test_file_repository_autopublish"
 one_version_repo="cli_test_one_version_repo"
 
 cleanup() {
-  pulp file remote destroy --name "cli_test_file_remote" || true
   pulp file repository destroy --name "cli_test_file_repository" || true
   pulp file repository destroy --name "$autopublish_repo" || true
   pulp file repository destroy --name "$one_version_repo" || true
+  pulp file remote destroy --name "cli_test_file_remote" || true
 }
 trap cleanup EXIT
 

--- a/tests/scripts/pulp_python/test_distribution.sh
+++ b/tests/scripts/pulp_python/test_distribution.sh
@@ -6,8 +6,8 @@
 pulp debug has-plugin --name "python" || exit 3
 
 cleanup() {
-  pulp python remote destroy --name "cli_test_python_remote" || true
   pulp python repository destroy --name "cli_test_python_repository" || true
+  pulp python remote destroy --name "cli_test_python_remote" || true
   pulp python distribution destroy --name "cli_test_python_distro" || true
   pulp orphan cleanup || true
 }

--- a/tests/scripts/pulp_python/test_publication.sh
+++ b/tests/scripts/pulp_python/test_publication.sh
@@ -6,8 +6,8 @@
 pulp debug has-plugin --name "python" || exit 3
 
 cleanup() {
-  pulp python remote destroy --name "cli_test_python_remote" || true
   pulp python repository destroy --name "cli_test_python_repository" || true
+  pulp python remote destroy --name "cli_test_python_remote" || true
   pulp orphan cleanup || true
 }
 trap cleanup EXIT

--- a/tests/scripts/pulp_python/test_sync.sh
+++ b/tests/scripts/pulp_python/test_sync.sh
@@ -6,8 +6,8 @@
 pulp debug has-plugin --name "python" || exit 3
 
 cleanup() {
-  pulp python remote destroy --name "cli_test_python_remote" || true
   pulp python repository destroy --name "cli_test_python_repository" || true
+  pulp python remote destroy --name "cli_test_python_remote" || true
   pulp orphan cleanup || true
 }
 trap cleanup EXIT

--- a/tests/scripts/pulp_rpm/test_acs.sh
+++ b/tests/scripts/pulp_rpm/test_acs.sh
@@ -9,9 +9,9 @@ acs_remote="cli_test_rpm_acs_remote"
 acs="cli_test_acs"
 
 cleanup() {
+  pulp rpm repository destroy --name "cli-repo-metadata-only" || true
   pulp rpm acs destroy --name $acs || true
   pulp rpm remote destroy --name $acs_remote || true
-  pulp rpm repository destroy --name "cli-repo-metadata-only" || true
   pulp rpm remote destroy --name "cli-remote-metadata-only" || true
   pulp orphan cleanup --protection-time 0 || true
 }

--- a/tests/scripts/pulp_rpm/test_content.sh
+++ b/tests/scripts/pulp_rpm/test_content.sh
@@ -14,8 +14,8 @@ PACKAGE_HREF=
 ADVISORY_HREF=
 cleanup() {
   pulp rpm repository destroy --name "${REPO1_NAME}" || true
-  pulp rpm remote destroy --name "${REPO1_NAME}" || true
   pulp rpm repository destroy --name "${REPO2_NAME}" || true
+  pulp rpm remote destroy --name "${REPO1_NAME}" || true
   pulp rpm remote destroy --name "${REPO2_NAME}" || true
   # clean up everything else "asap"
   pulp orphan cleanup --protection-time 0 || true

--- a/tests/scripts/pulpcore/test_pulpexporter.sh
+++ b/tests/scripts/pulpcore/test_pulpexporter.sh
@@ -14,9 +14,9 @@ PATH1="/tmp/exports"
 PATH2="/tmp/export-path-changed"
 
 cleanup() {
-  pulp file remote destroy --name $RMOTE || true
   pulp file repository destroy --name $REPO1 || true
   pulp file repository destroy --name $REPO2 || true
+  pulp file remote destroy --name $RMOTE || true
   pulp exporter pulp destroy --name $NAME1 || true
   pulp exporter pulp destroy --name $NAME2 || true
 }

--- a/tests/scripts/pulpcore/test_task.sh
+++ b/tests/scripts/pulpcore/test_task.sh
@@ -6,9 +6,9 @@
 pulp debug has-plugin --name "file" || exit 3
 
 cleanup() {
+  pulp file repository destroy --name "cli_test_file_repository" || true
   pulp file remote destroy --name "cli_test_file_remote" || true
   pulp file remote destroy --name "cli_test_file_large_remote" || true
-  pulp file repository destroy --name "cli_test_file_repository" || true
   pulp orphan cleanup || true
 }
 trap cleanup EXIT


### PR DESCRIPTION
This is a pre-requirement for merging the change that influences the way
how we remove remotes. The remotes will be possible to remove only after
removing repositories that are using their resources.

[noissue]
