### PR TITLE
Checks if the list of repositories is sorted in reverse alphabetical order

### DIFF
--- a/CHANGES/569.misc
+++ b/CHANGES/569.misc
@@ -1,0 +1,1 @@
+Fixed the ordering test to work with pulpcore 3.16 and 3.18. 

--- a/tests/scripts/pulpcore/test_query_params.sh
+++ b/tests/scripts/pulpcore/test_query_params.sh
@@ -17,10 +17,14 @@ expect_succ pulp file repository create --name bbbbbbbbbb
 expect_succ pulp file repository create --name cccccccccc
 
 expect_succ pulp file repository list --ordering -name
-ORDERED_RESULTS=$(echo "$OUTPUT" | jq -r .[].name | tr "\n" " " | xargs)
-EXPECTED_RESULTS="cccccccccc bbbbbbbbbb aaaaaaaaaa"
-if [[ "$ORDERED_RESULTS" != "$EXPECTED_RESULTS" ]]; then
-  echo "Ordered results do not match: {$ORDERED_RESULTS} != {$EXPECTED_RESULTS}"
+if ! (echo "$OUTPUT" | jq -r .[].name | sort -r -C -); then
+  echo -e "Ordered results are not in a reverse alphabetical order.\n$(echo "$OUTPUT" | jq -r .[].name)"
+  exit 1
+fi
+
+expect_succ pulp file repository list --ordering name
+if ! (echo "$OUTPUT" | jq -r .[].name | sort -C -); then
+  echo -e "Ordered results are not in an alphabetical order.\n$(echo "$OUTPUT" | jq -r .[].name)"
   exit 1
 fi
 


### PR DESCRIPTION
fixes: #569
