### PR TITLE
Fix [exclude-]fields in ansible content list

### DIFF
--- a/CHANGES/602.bugfix
+++ b/CHANGES/602.bugfix
@@ -1,0 +1,1 @@
+Deprecated `--fields` and `--exclude-fields` on `pulp ansible content list` in favor of `--[exclude-]field`.


### PR DESCRIPTION
Deprecated the plural --[exclude-]fields parameters and made the default value compatible with the generic --[exclude-]field options.

fixes #602

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
