### PR TITLE
Refine sync commands

### DIFF
--- a/pulpcore/cli/ansible/context.py
+++ b/pulpcore/cli/ansible/context.py
@@ -88,7 +88,10 @@ class PulpAnsibleRepositoryContext(PulpRepositoryContext):
     ENTITY = _("ansible repository")
     ENTITIES = _("ansible repositories")
     VERSION_CONTEXT = PulpAnsibleRepositoryVersionContext
-    CAPABILITIES = {"pulpexport": [PluginRequirement("ansible")]}
+    CAPABILITIES = {
+        "sync": [PluginRequirement("ansible")],
+        "pulpexport": [PluginRequirement("ansible")],
+    }
     NULLABLES = PulpRepositoryContext.NULLABLES | {"gpgkey"}
 
 

--- a/pulpcore/cli/ansible/distribution.py
+++ b/pulpcore/cli/ansible/distribution.py
@@ -110,7 +110,6 @@ def update(
     To remove repository or repository_version fields set --repository to ""
     """
     dist_body: EntityDefinition = distribution_ctx.entity
-    href: str = dist_body["pulp_href"]
     name: str = dist_body["name"]
     body: EntityDefinition = dict()
 
@@ -129,18 +128,16 @@ def update(
             repo = repository.entity
             if version is not None:
                 if dist_body["repository"]:
-                    distribution_ctx.update(href, body={"repository": ""}, non_blocking=True)
+                    distribution_ctx.update(body={"repository": ""}, non_blocking=True)
                 body["repository_version"] = f'{repo["versions_href"]}{version}/'
             else:
                 if dist_body["repository_version"]:
-                    distribution_ctx.update(
-                        href, body={"repository_version": ""}, non_blocking=True
-                    )
+                    distribution_ctx.update(body={"repository_version": ""}, non_blocking=True)
                 body["repository"] = repo["pulp_href"]
     elif version is not None:
         # keep current repository, change version
         if dist_body["repository"]:
-            distribution_ctx.update(href, body={"repository": ""}, non_blocking=True)
+            distribution_ctx.update(body={"repository": ""}, non_blocking=True)
             body["repository_version"] = f'{dist_body["repository"]}versions/{version}/'
         elif dist_body["repository_version"]:
             repository_href, _, _ = dist_body["repository_version"].partition("versions")
@@ -152,4 +149,4 @@ def update(
                     "please specify the repository to use  with --repository"
                 ).format(name=name)
             )
-    distribution_ctx.update(href, body=body)
+    distribution_ctx.update(body=body)

--- a/pulpcore/cli/ansible/repository.py
+++ b/pulpcore/cli/ansible/repository.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 import click
 import schema as s
@@ -13,7 +13,6 @@ from pulpcore.cli.ansible.context import (
 from pulpcore.cli.common.context import (
     EntityFieldDefinition,
     PluginRequirement,
-    PulpEntityContext,
     PulpRemoteContext,
     PulpRepositoryContext,
 )
@@ -200,14 +199,15 @@ def sync(
     remote: EntityFieldDefinition,
 ) -> None:
     """
+    Sync the repository from a remote source.
     If remote is not specified sync will try to use the default remote associated with
     the repository
     """
     repository = repository_ctx.entity
-    repository_href = repository["pulp_href"]
-    body = {}
-    if isinstance(remote, PulpEntityContext):
-        body["remote"] = remote.pulp_href
+    body: Dict[str, Any] = {}
+
+    if remote:
+        body["remote"] = remote
     elif repository["remote"] is None:
         name = repository["name"]
         raise click.ClickException(
@@ -217,10 +217,7 @@ def sync(
             ).format(name=name)
         )
 
-    repository_ctx.sync(
-        href=repository_href,
-        body=body,
-    )
+    repository_ctx.sync(body=body)
 
 
 @repository.command()
@@ -237,6 +234,6 @@ def sign(
     """Sign the collections in the repository using the signing service specified."""
     if content_units is None:
         content_units = ["*"]
-    body = {"content_units": content_units, "signing_service": signing_service.pulp_href}
+    body = {"content_units": content_units, "signing_service": signing_service}
     parameters = {repository_ctx.HREF: repository_ctx.pulp_href}
     repository_ctx.call("sign", parameters=parameters, body=body)

--- a/pulpcore/cli/common/context.py
+++ b/pulpcore/cli/common/context.py
@@ -636,7 +636,7 @@ class PulpEntityContext:
         # We would have a dedicated api for this ideally.
         labels = self.entity["pulp_labels"]
         labels[key] = value
-        return self.update(self.pulp_href, body={"pulp_labels": labels}, non_blocking=non_blocking)
+        return self.update(body={"pulp_labels": labels}, non_blocking=non_blocking)
 
     def unset_label(self, key: str, non_blocking: bool = False) -> Any:
         # We would have a dedicated api for this ideally.
@@ -645,7 +645,7 @@ class PulpEntityContext:
             labels.pop(key)
         except KeyError:
             raise PulpException(_("Could not find label with key '{key}'.").format(key=key))
-        return self.update(self.pulp_href, body={"pulp_labels": labels}, non_blocking=non_blocking)
+        return self.update(body={"pulp_labels": labels}, non_blocking=non_blocking)
 
     def show_label(self, key: str) -> Any:
         # We would have a dedicated api for this ideally.
@@ -743,7 +743,7 @@ class PulpRepositoryVersionContext(PulpEntityContext):
     def scope(self) -> Dict[str, Any]:
         return {self.repository_ctx.HREF: self.repository_ctx.pulp_href}
 
-    def repair(self, href: Optional[str]) -> Any:
+    def repair(self, href: Optional[str] = None) -> Any:
         return self.call("repair", parameters={self.HREF: href or self.pulp_href}, body={})
 
 
@@ -773,12 +773,12 @@ class PulpRepositoryContext(PulpEntityContext):
                 body["retained_versions"] = body.pop("retain_repo_versions")
         return body
 
-    def sync(self, href: str, body: Dict[str, Any]) -> Any:
-        return self.call("sync", parameters={self.HREF: href}, body=body)
+    def sync(self, href: Optional[str] = None, body: Optional[EntityDefinition] = None) -> Any:
+        return self.call("sync", parameters={self.HREF: href or self.pulp_href}, body=body or {})
 
     def modify(
         self,
-        href: str,
+        href: Optional[str] = None,
         add_content: Optional[List[str]] = None,
         remove_content: Optional[List[str]] = None,
         base_version: Optional[str] = None,
@@ -790,7 +790,7 @@ class PulpRepositoryContext(PulpEntityContext):
             body["remove_content_units"] = remove_content
         if base_version is not None:
             body["base_version"] = base_version
-        return self.call("modify", parameters={self.HREF: href}, body=body)
+        return self.call("modify", parameters={self.HREF: href or self.pulp_href}, body=body)
 
 
 class PulpContentContext(PulpEntityContext):

--- a/pulpcore/cli/common/context.py
+++ b/pulpcore/cli/common/context.py
@@ -803,6 +803,14 @@ class PulpContentContext(PulpEntityContext):
     ID_PREFIX = "content"
 
 
+class PulpACSContext(PulpEntityContext):
+    ENTITY = _("ACS")
+    ENTITIES = _("ACSes")
+
+    def refresh(self, href: Optional[str] = None) -> Any:
+        return self.call("refresh", parameters={self.HREF: href or self.pulp_href})
+
+
 EntityFieldDefinition = Union[None, str, PulpEntityContext]
 
 

--- a/pulpcore/cli/common/generic.py
+++ b/pulpcore/cli/common/generic.py
@@ -1024,7 +1024,7 @@ def update_command(**kwargs: Any) -> click.Command:
         """
         Update a {entity}.
         """
-        entity_ctx.update(href=entity_ctx.pulp_href, body=kwargs)
+        entity_ctx.update(body=kwargs)
 
     for option in decorators:
         # Decorate callback
@@ -1045,7 +1045,7 @@ def destroy_command(**kwargs: Any) -> click.Command:
         """
         Destroy a {entity}.
         """
-        entity_ctx.delete(entity_ctx.pulp_href)
+        entity_ctx.delete()
 
     for option in decorators:
         # Decorate callback
@@ -1081,8 +1081,7 @@ def version_command(**kwargs: Any) -> click.Command:
         pulp_ctx: PulpCLIContext,
         repository_version_ctx: PulpRepositoryVersionContext,
     ) -> None:
-        href = repository_version_ctx.pulp_href
-        result = repository_version_ctx.repair(href)
+        result = repository_version_ctx.repair()
         pulp_ctx.output_result(result)
 
     return callback
@@ -1246,11 +1245,7 @@ def repository_content_command(**kwargs: Any) -> click.Group:
         base_version: PulpRepositoryVersionContext,
     ) -> None:
         repo_ctx = base_version.repository_ctx
-        repo_ctx.modify(
-            repo_ctx.pulp_href,
-            add_content=[content_ctx.pulp_href],
-            base_version=base_version.pulp_href,
-        )
+        repo_ctx.modify(add_content=[content_ctx.pulp_href], base_version=base_version.pulp_href)
 
     @pulp_command("remove")
     @click.option("--all", is_flag=True, help=_("Remove all content from repository version"))
@@ -1264,9 +1259,7 @@ def repository_content_command(**kwargs: Any) -> click.Group:
     ) -> None:
         repo_ctx = base_version.repository_ctx
         remove_content = ["*" if all else content_ctx.pulp_href]
-        repo_ctx.modify(
-            repo_ctx.pulp_href, remove_content=remove_content, base_version=base_version.pulp_href
-        )
+        repo_ctx.modify(remove_content=remove_content, base_version=base_version.pulp_href)
 
     @pulp_command("modify")
     @repository_option
@@ -1279,7 +1272,7 @@ def repository_content_command(**kwargs: Any) -> click.Group:
         repo_ctx = base_version.repository_ctx
         ac = [unit.pulp_href for unit in add_content] if add_content else None
         rc = [unit.pulp_href for unit in remove_content] if remove_content else None
-        repo_ctx.modify(repo_ctx.pulp_href, ac, rc, base_version.pulp_href)
+        repo_ctx.modify(add_content=ac, remove_content=rc, base_version=base_version.pulp_href)
 
     command_decorators: Dict[click.Command, Optional[List[Callable[[FC], FC]]]] = {
         content_list: kwargs.pop("list_decorators", []),

--- a/pulpcore/cli/container/context.py
+++ b/pulpcore/cli/container/context.py
@@ -119,17 +119,23 @@ class PulpContainerRepositoryContext(PulpContainerBaseRepositoryContext):
 
     def modify(
         self,
-        href: str,
+        href: Optional[str] = None,
         add_content: Optional[List[str]] = None,
         remove_content: Optional[List[str]] = None,
         base_version: Optional[str] = None,
     ) -> Any:
         if remove_content:
             self.call(
-                "remove", parameters={self.HREF: href}, body={"content_units": remove_content}
+                "remove",
+                parameters={self.HREF: href or self.pulp_href},
+                body={"content_units": remove_content},
             )
         if add_content:
-            self.call("add", parameters={self.HREF: href}, body={"content_units": add_content})
+            self.call(
+                "add",
+                parameters={self.HREF: href or self.pulp_href},
+                body={"content_units": add_content},
+            )
 
     def copy_tag(self, source_href: str, tags: Optional[List[str]]) -> Any:
         body = {"source_repository_version": source_href, "names": tags}

--- a/pulpcore/cli/container/distribution.py
+++ b/pulpcore/cli/container/distribution.py
@@ -97,7 +97,6 @@ def update(
     pulp_labels: Optional[Dict[str, str]],
 ) -> None:
     distribution: EntityDefinition = distribution_ctx.entity
-    href: str = distribution_ctx.pulp_href
     body: EntityDefinition = {}
 
     if private is not None:
@@ -117,18 +116,16 @@ def update(
             repository = cast(PulpEntityContext, repository)
             if version is not None:
                 if distribution["repository"]:
-                    distribution_ctx.update(href, body={"repository": ""}, non_blocking=True)
+                    distribution_ctx.update(body={"repository": ""}, non_blocking=True)
                 body["repository_version"] = f"{repository.pulp_href}versions/{version}/"
             else:
                 if distribution["repository_version"]:
-                    distribution_ctx.update(
-                        href, body={"repository_version": ""}, non_blocking=True
-                    )
+                    distribution_ctx.update(body={"repository_version": ""}, non_blocking=True)
                 body["repository"] = repository.pulp_href
     elif version is not None:
         # keep current repository, change version
         if distribution["repository"]:
-            distribution_ctx.update(href, body={"repository": ""}, non_blocking=True)
+            distribution_ctx.update(body={"repository": ""}, non_blocking=True)
             body["repository_version"] = f'{distribution["repository"]}versions/{version}/'
         elif distribution["repository_version"]:
             repository_href, _, _ = distribution["repository_version"].partition("versions")
@@ -140,4 +137,4 @@ def update(
                     "please specify the repository to use  with --repository"
                 ).format(distribution=distribution["name"])
             )
-    distribution_ctx.update(href, body=body)
+    distribution_ctx.update(body=body)

--- a/pulpcore/cli/container/repository.py
+++ b/pulpcore/cli/container/repository.py
@@ -5,7 +5,6 @@ import click
 
 from pulpcore.cli.common.context import (
     EntityFieldDefinition,
-    PulpEntityContext,
     PulpRemoteContext,
     PulpRepositoryContext,
 )
@@ -153,16 +152,19 @@ def sync(
     repository_ctx: PulpRepositoryContext,
     remote: EntityFieldDefinition,
 ) -> None:
+    """
+    Sync the repository from a remote source.
+    If remote is not specified sync will try to use the default remote associated with
+    the repository
+    """
     if not repository_ctx.capable("sync"):
         raise click.ClickException(_("Repository type does not support sync."))
 
     repository = repository_ctx.entity
-    repository_href = repository_ctx.pulp_href
-
     body: Dict[str, Any] = {}
 
-    if isinstance(remote, PulpEntityContext):
-        body["remote"] = remote.pulp_href
+    if remote:
+        body["remote"] = remote
     elif repository["remote"] is None:
         raise click.ClickException(
             _(
@@ -171,10 +173,7 @@ def sync(
             ).format(name=repository["name"])
         )
 
-    repository_ctx.sync(
-        href=repository_href,
-        body=body,
-    )
+    repository_ctx.sync(body=body)
 
 
 @repository.command(name="tag")

--- a/pulpcore/cli/core/artifact.py
+++ b/pulpcore/cli/core/artifact.py
@@ -44,6 +44,5 @@ def upload(
     file: IO[bytes],
     chunk_size: int,
 ) -> None:
-    artifact_href = artifact_ctx.upload(file, chunk_size)
-    result = artifact_ctx.show(artifact_href)
-    pulp_ctx.output_result(result)
+    artifact_ctx.upload(file, chunk_size)
+    pulp_ctx.output_result(artifact_ctx.entity)

--- a/pulpcore/cli/core/content_guard.py
+++ b/pulpcore/cli/core/content_guard.py
@@ -79,8 +79,7 @@ def assign(
     users: Optional[List[str]],
     groups: Optional[List[str]],
 ) -> None:
-    href = guard_ctx.entity["pulp_href"]
-    result = guard_ctx.assign(href=href, users=users, groups=groups)
+    result = guard_ctx.assign(users=users, groups=groups)
     pulp_ctx.output_result(result)
 
 
@@ -107,8 +106,7 @@ def remove(
     users: Optional[List[str]],
     groups: Optional[List[str]],
 ) -> None:
-    href = guard_ctx.entity["pulp_href"]
-    result = guard_ctx.remove(href=href, users=users, groups=groups)
+    result = guard_ctx.remove(users=users, groups=groups)
     pulp_ctx.output_result(result)
 
 

--- a/pulpcore/cli/core/exporter.py
+++ b/pulpcore/cli/core/exporter.py
@@ -101,7 +101,6 @@ def update(
     repository: Iterable[EntityFieldDefinition],
     repository_href: Iterable[str],
 ) -> None:
-    exporter_href = exporter_ctx.pulp_href
     payload: Dict[str, Any] = {}
 
     if path:
@@ -114,4 +113,4 @@ def update(
             if isinstance(repository_ctx, PulpEntityContext)
         ] + list(repository_href)
 
-    exporter_ctx.update(exporter_href, payload)
+    exporter_ctx.update(body=payload)

--- a/pulpcore/cli/core/group.py
+++ b/pulpcore/cli/core/group.py
@@ -158,6 +158,7 @@ def remove_user(pulp_ctx: PulpCLIContext, entity_ctx: PulpGroupUserContext, user
     user_href = PulpUserContext(pulp_ctx).find(username=username)["pulp_href"]
     user_pk = user_href.split("/")[-2]
     group_user_href = f"{entity_ctx.group_ctx.pulp_href}users/{user_pk}/"
+    # TODO Check if this can be transformed to a preloaded context.
     entity_ctx.delete(group_user_href)
 
 

--- a/pulpcore/cli/core/importer.py
+++ b/pulpcore/cli/core/importer.py
@@ -82,11 +82,10 @@ def update(
     importer_ctx: PulpImporterContext,
     repo_map: List[RepositoryMap],
 ) -> None:
-    importer_href = importer_ctx.pulp_href
     payload = {}
 
     if repo_map:
         payload["repo_mapping"] = {source: dest for source, dest in repo_map}
 
-    result = importer_ctx.update(importer_href, payload)
+    result = importer_ctx.update(body=payload)
     pulp_ctx.output_result(result)

--- a/pulpcore/cli/file/acs.py
+++ b/pulpcore/cli/file/acs.py
@@ -61,8 +61,7 @@ def path() -> None:
 def add(acs_ctx: PulpFileACSContext, paths: Iterable[str]) -> None:
     """Add path(s) to an existing ACS."""
     paths = set(paths)
-    href = acs_ctx.entity["pulp_href"]
-    existing_paths = set(acs_ctx.show(href)["paths"])
+    existing_paths = set(acs_ctx.entity["paths"])
 
     for path in paths:
         if path in existing_paths:
@@ -70,7 +69,7 @@ def add(acs_ctx: PulpFileACSContext, paths: Iterable[str]) -> None:
 
     if existing_paths != {""}:
         paths = set.union(existing_paths, paths)
-    acs_ctx.update(href, body={"paths": list(paths)})
+    acs_ctx.update(body={"paths": list(paths)})
 
 
 @path.command()
@@ -81,15 +80,14 @@ def add(acs_ctx: PulpFileACSContext, paths: Iterable[str]) -> None:
 def remove(acs_ctx: PulpFileACSContext, paths: Iterable[str]) -> None:
     """Remove path(s) from an existing ACS."""
     paths = set(paths)
-    href = acs_ctx.entity["pulp_href"]
-    existing_paths = set(acs_ctx.show(href)["paths"])
+    existing_paths = set(acs_ctx.entity["paths"])
 
     if paths - existing_paths:
         missing_paths = paths - existing_paths
         raise click.ClickException(_("ACS does not have path(s): {}.").format(missing_paths))
 
     paths = existing_paths - paths
-    acs_ctx.update(href, body={"paths": list(paths)})
+    acs_ctx.update(body={"paths": list(paths)})
 
 
 remote_option = resource_option(
@@ -118,4 +116,4 @@ acs.add_command(role_command(decorators=lookup_options))
 @href_option
 @name_option
 def refresh(pulp_ctx: PulpCLIContext, acs_ctx: PulpFileACSContext) -> None:
-    acs_ctx.refresh(acs_ctx.pulp_href)
+    acs_ctx.refresh()

--- a/pulpcore/cli/file/context.py
+++ b/pulpcore/cli/file/context.py
@@ -1,8 +1,7 @@
-from typing import Any, Optional
-
 from pulpcore.cli.common.context import (
     EntityDefinition,
     PluginRequirement,
+    PulpACSContext,
     PulpContentContext,
     PulpEntityContext,
     PulpRemoteContext,
@@ -16,16 +15,13 @@ translation = get_translation(__name__)
 _ = translation.gettext
 
 
-class PulpFileACSContext(PulpEntityContext):
+class PulpFileACSContext(PulpACSContext):
     ENTITY = _("file ACS")
     ENTITIES = _("file ACSes")
     HREF = "file_file_alternate_content_source_href"
     ID_PREFIX = "acs_file_file"
     NEEDS_PLUGINS = [PluginRequirement("file", "1.9.0")]
     CAPABILITIES = {"roles": [PluginRequirement("file", min="1.11.0")]}
-
-    def refresh(self, href: Optional[str] = None) -> Any:
-        return self.call("refresh", parameters={self.HREF: href or self.pulp_href})
 
 
 class PulpFileContentContext(PulpContentContext):

--- a/pulpcore/cli/file/context.py
+++ b/pulpcore/cli/file/context.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from pulpcore.cli.common.context import (
     EntityDefinition,
@@ -24,8 +24,8 @@ class PulpFileACSContext(PulpEntityContext):
     NEEDS_PLUGINS = [PluginRequirement("file", "1.9.0")]
     CAPABILITIES = {"roles": [PluginRequirement("file", min="1.11.0")]}
 
-    def refresh(self, href: str) -> Any:
-        return self.call("refresh", parameters={self.HREF: href})
+    def refresh(self, href: Optional[str] = None) -> Any:
+        return self.call("refresh", parameters={self.HREF: href or self.pulp_href})
 
 
 class PulpFileContentContext(PulpContentContext):
@@ -90,6 +90,7 @@ class PulpFileRepositoryContext(PulpRepositoryContext):
     ID_PREFIX = "repositories_file_file"
     VERSION_CONTEXT = PulpFileRepositoryVersionContext
     CAPABILITIES = {
+        "sync": [PluginRequirement("file")],
         "pulpexport": [PluginRequirement("file")],
         "roles": [PluginRequirement("file", min="1.11.0")],
     }

--- a/pulpcore/cli/file/repository.py
+++ b/pulpcore/cli/file/repository.py
@@ -6,7 +6,6 @@ import schema as s
 from pulpcore.cli.common.context import (
     EntityFieldDefinition,
     PluginRequirement,
-    PulpEntityContext,
     PulpRemoteContext,
     PulpRepositoryContext,
 )
@@ -180,13 +179,16 @@ def sync(
     repository_ctx: PulpRepositoryContext,
     remote: EntityFieldDefinition,
 ) -> None:
-    repository = repository_ctx.entity
-    repository_href = repository_ctx.pulp_href
-
+    """
+    Sync the repository from a remote source.
+    If remote is not specified sync will try to use the default remote associated with
+    the repository
+    """
     body: Dict[str, Any] = {}
+    repository = repository_ctx.entity
 
-    if isinstance(remote, PulpEntityContext):
-        body["remote"] = remote.pulp_href
+    if remote:
+        body["remote"] = remote
     elif repository["remote"] is None:
         raise click.ClickException(
             _(
@@ -195,10 +197,7 @@ def sync(
             ).format(name=repository["name"])
         )
 
-    repository_ctx.sync(
-        href=repository_href,
-        body=body,
-    )
+    repository_ctx.sync(body=body)
 
 
 @repository.command(deprecated=True)
@@ -230,7 +229,6 @@ def add(
     ).pulp_href
 
     repository_ctx.modify(
-        href=repository_href,
         add_content=[content_href],
         base_version=base_version_href,
     )
@@ -265,7 +263,6 @@ def remove(
     ).pulp_href
 
     repository_ctx.modify(
-        href=repository_href,
         remove_content=[content_href],
         base_version=base_version_href,
     )
@@ -323,7 +320,6 @@ def modify(
     ]
 
     repository_ctx.modify(
-        href=repository_href,
         add_content=add_content_href,
         remove_content=remove_content_href,
         base_version=base_version_href,

--- a/pulpcore/cli/migration/context.py
+++ b/pulpcore/cli/migration/context.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from pulpcore.cli.common.context import PulpEntityContext
 from pulpcore.cli.common.i18n import get_translation
@@ -12,11 +12,15 @@ class PulpMigrationPlanContext(PulpEntityContext):
     HREF = "pulp_2to3_migration_migration_plan_href"
     ID_PREFIX = "migration_plans"
 
-    def run(self, href: str) -> Any:
-        return self.pulp_ctx.call("migration_plans_run", parameters={self.HREF: href})
+    def run(self, href: Optional[str] = None) -> Any:
+        return self.pulp_ctx.call(
+            "migration_plans_run", parameters={self.HREF: href or self.pulp_href}
+        )
 
-    def reset(self, href: str) -> Any:
-        return self.pulp_ctx.call("migration_plans_reset", parameters={self.HREF: href})
+    def reset(self, href: Optional[str] = None) -> Any:
+        return self.pulp_ctx.call(
+            "migration_plans_reset", parameters={self.HREF: href or self.pulp_href}
+        )
 
 
 class PulpMigrationPulp2ContentContext(PulpEntityContext):

--- a/pulpcore/cli/python/context.py
+++ b/pulpcore/cli/python/context.py
@@ -71,6 +71,7 @@ class PulpPythonRepositoryContext(PulpRepositoryContext):
     ENTITIES = _("python repositories")
     ID_PREFIX = "repositories_python_python"
     VERSION_CONTEXT = PulpPythonRepositoryVersionContext
+    CAPABILITIES = {"sync": [PluginRequirement("python")]}
 
 
 registered_repository_contexts["python:python"] = PulpPythonRepositoryContext

--- a/pulpcore/cli/python/repository.py
+++ b/pulpcore/cli/python/repository.py
@@ -5,7 +5,6 @@ import click
 from pulpcore.cli.common.context import (
     EntityFieldDefinition,
     PluginRequirement,
-    PulpEntityContext,
     PulpRemoteContext,
     PulpRepositoryContext,
 )
@@ -153,13 +152,16 @@ def sync(
     repository_ctx: PulpRepositoryContext,
     remote: EntityFieldDefinition,
 ) -> None:
+    """
+    Sync the repository from a remote source.
+    If remote is not specified sync will try to use the default remote associated with
+    the repository
+    """
     repository = repository_ctx.entity
-    repository_href = repository_ctx.pulp_href
-
     body: Dict[str, Any] = {}
 
-    if isinstance(remote, PulpEntityContext):
-        body["remote"] = remote.pulp_href
+    if remote:
+        body["remote"] = remote
     elif repository["remote"] is None:
         raise click.ClickException(
             _(
@@ -168,10 +170,7 @@ def sync(
             ).format(name=repository["name"])
         )
 
-    repository_ctx.sync(
-        href=repository_href,
-        body=body,
-    )
+    repository_ctx.sync(body=body)
 
 
 @repository.command(deprecated=True)
@@ -199,7 +198,6 @@ def add(
     content_href = PulpPythonContentContext(pulp_ctx, entity={"filename": filename}).pulp_href
 
     repository_ctx.modify(
-        href=repository_href,
         add_content=[content_href],
         base_version=base_version_href,
     )
@@ -230,7 +228,6 @@ def remove(
     content_href = PulpPythonContentContext(pulp_ctx, entity={"filename": filename}).pulp_href
 
     repository_ctx.modify(
-        href=repository_href,
         remove_content=[content_href],
         base_version=base_version_href,
     )

--- a/pulpcore/cli/rpm/acs.py
+++ b/pulpcore/cli/rpm/acs.py
@@ -60,8 +60,7 @@ def path() -> None:
 def add(acs_ctx: PulpRpmACSContext, paths: Iterable[str]) -> None:
     """Add path(s) to an existing ACS."""
     paths = set(paths)
-    href = acs_ctx.entity["pulp_href"]
-    existing_paths = set(acs_ctx.show(href)["paths"])
+    existing_paths = set(acs_ctx.entity["paths"])
 
     for path in paths:
         if path in existing_paths:
@@ -69,7 +68,7 @@ def add(acs_ctx: PulpRpmACSContext, paths: Iterable[str]) -> None:
 
     if existing_paths != {""}:
         paths = set.union(existing_paths, paths)
-    acs_ctx.update(href, body={"paths": list(paths)})
+    acs_ctx.update(body={"paths": list(paths)})
 
 
 @path.command()
@@ -80,15 +79,14 @@ def add(acs_ctx: PulpRpmACSContext, paths: Iterable[str]) -> None:
 def remove(acs_ctx: PulpRpmACSContext, paths: Iterable[str]) -> None:
     """Remove path(s) from an existing ACS."""
     paths = set(paths)
-    href = acs_ctx.entity["pulp_href"]
-    existing_paths = set(acs_ctx.show(href)["paths"])
+    existing_paths = set(acs_ctx.entity["paths"])
 
     if paths - existing_paths:
         missing_paths = paths - existing_paths
         raise click.ClickException(_("ACS does not have path(s): {}.").format(missing_paths))
 
     paths = existing_paths - paths
-    acs_ctx.update(href, body={"paths": list(paths)})
+    acs_ctx.update(body={"paths": list(paths)})
 
 
 remote_option = resource_option(
@@ -116,4 +114,4 @@ acs.add_command(destroy_command(decorators=lookup_options))
 @href_option
 @name_option
 def refresh(pulp_ctx: PulpCLIContext, acs_ctx: PulpRpmACSContext) -> None:
-    acs_ctx.refresh(acs_ctx.pulp_href)
+    acs_ctx.refresh()

--- a/pulpcore/cli/rpm/context.py
+++ b/pulpcore/cli/rpm/context.py
@@ -26,8 +26,11 @@ class PulpRpmACSContext(PulpEntityContext):
     ID_PREFIX = "acs_rpm_rpm"
     NEEDS_PLUGINS = [PluginRequirement("rpm", "3.18.0")]
 
-    def refresh(self, href: str) -> Any:
-        return self.call("refresh", parameters={self.HREF: href})
+    def refresh(self, href: Optional[str] = None) -> Any:
+        return self.call(
+            "refresh",
+            parameters={self.HREF: href or self.pulp_href},
+        )
 
 
 class PulpRpmCompsXmlContext(PulpEntityContext):
@@ -194,7 +197,7 @@ class PulpRpmRepositoryContext(PulpRepositoryContext):
     ENTITY = _("rpm repository")
     ENTITIES = _("rpm repositories")
     VERSION_CONTEXT = PulpRpmRepositoryVersionContext
-    CAPABILITIES = {"pulpexport": [PluginRequirement("rpm")]}
+    CAPABILITIES = {"sync": [PluginRequirement("rpm")], "pulpexport": [PluginRequirement("rpm")]}
 
 
 registered_repository_contexts["rpm:rpm"] = PulpRpmRepositoryContext

--- a/pulpcore/cli/rpm/context.py
+++ b/pulpcore/cli/rpm/context.py
@@ -5,6 +5,7 @@ import click
 from pulpcore.cli.common.context import (
     EntityDefinition,
     PluginRequirement,
+    PulpACSContext,
     PulpContentContext,
     PulpEntityContext,
     PulpException,
@@ -19,18 +20,12 @@ translation = get_translation(__name__)
 _ = translation.gettext
 
 
-class PulpRpmACSContext(PulpEntityContext):
+class PulpRpmACSContext(PulpACSContext):
     ENTITY = _("rpm ACS")
     ENTITIES = _("rpm ACSes")
     HREF = "rpm_rpm_alternate_content_source_href"
     ID_PREFIX = "acs_rpm_rpm"
     NEEDS_PLUGINS = [PluginRequirement("rpm", "3.18.0")]
-
-    def refresh(self, href: Optional[str] = None) -> Any:
-        return self.call(
-            "refresh",
-            parameters={self.HREF: href or self.pulp_href},
-        )
 
 
 class PulpRpmCompsXmlContext(PulpEntityContext):

--- a/pulpcore/cli/rpm/repository.py
+++ b/pulpcore/cli/rpm/repository.py
@@ -6,7 +6,6 @@ import schema as s
 from pulpcore.cli.common.context import (
     EntityFieldDefinition,
     PluginRequirement,
-    PulpEntityContext,
     PulpRemoteContext,
     PulpRepositoryContext,
 )
@@ -212,9 +211,12 @@ def sync(
     skip_types: Optional[Iterable[str]],
     sync_policy: Optional[str],
 ) -> None:
+    """
+    Sync the repository from a remote source.
+    If remote is not specified sync will try to use the default remote associated with
+    the repository
+    """
     repository = repository_ctx.entity
-    repository_href = repository_ctx.pulp_href
-
     body: Dict[str, Any] = {}
 
     if mirror:
@@ -226,8 +228,8 @@ def sync(
     if sync_policy:
         body["sync_policy"] = sync_policy
 
-    if isinstance(remote, PulpEntityContext):
-        body["remote"] = remote.pulp_href
+    if remote:
+        body["remote"] = remote
     elif repository["remote"] is None:
         raise click.ClickException(
             _(
@@ -236,7 +238,4 @@ def sync(
             ).format(name=repository["name"])
         )
 
-    repository_ctx.sync(
-        href=repository_href,
-        body=body,
-    )
+    repository_ctx.sync(body=body)


### PR DESCRIPTION
[noissue]

Note: This change strives to make the use of the context objects associated with a server side object easier, by leveraging the fact that the context already has this connection.
Example code:
```python
repo_ctx.sync(repo_ctx.pulp_href)
```
turns into
```python
repo_ctx.sync()
```

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
