### PR TITLE
Add pulp task summary command

### DIFF
--- a/CHANGES/625.feature
+++ b/CHANGES/625.feature
@@ -1,0 +1,1 @@
+Added the `pulp task summary` command as a replacement for `pulp debug task-summary`.

--- a/CHANGES/625.removal
+++ b/CHANGES/625.removal
@@ -1,0 +1,1 @@
+Deprecated `pulp debug task-summary` in favor of `pulp task summary`.

--- a/pulpcore/cli/common/debug.py
+++ b/pulpcore/cli/common/debug.py
@@ -39,7 +39,7 @@ def has_plugin(
     sys.exit(0 if available else 1)
 
 
-@debug.command()
+@debug.command(deprecated=True)
 @pass_pulp_context
 def task_summary(pulp_ctx: PulpCLIContext) -> None:
     """

--- a/pulpcore/cli/core/task.py
+++ b/pulpcore/cli/core/task.py
@@ -196,3 +196,14 @@ def purge(
     pulp_ctx.needs_plugin(PluginRequirement("core", "3.17.0"))
     state_list = list(state) if state else None
     task_ctx.purge(finished, state_list)
+
+
+@task.command()
+@pass_entity_context
+@pass_pulp_context
+def summary(pulp_ctx: PulpCLIContext, task_ctx: PulpTaskContext) -> None:
+    """
+    List a summary of tasks by status.
+    """
+    result = task_ctx.summary()
+    pulp_ctx.output_result(result)

--- a/tests/scripts/pulpcore/test_task.sh
+++ b/tests/scripts/pulpcore/test_task.sh
@@ -98,3 +98,6 @@ then
   expect_fail pulp task purge --finished-before "2021-12-01T12:00:00" --state "NOT A STATE"
   expect_fail pulp task purge --finished-before "2021-12-01T12:00:00" --state "running"
 fi
+
+# Test task summary
+expect_succ pulp task summary

--- a/tests/scripts/test_debug.sh
+++ b/tests/scripts/test_debug.sh
@@ -4,7 +4,6 @@
 . "$(dirname "$(realpath "$0")")"/config.source
 
 expect_succ pulp debug has-plugin --name "core" --max-version "4.0"
-expect_succ pulp debug task-summary
 expect_succ pulp debug openapi spec
 expect_succ pulp debug openapi operation-ids
 expect_succ pulp debug openapi operation --id tasks_list


### PR DESCRIPTION
As a replacement for "pulp debug task-summary" command which is deprecated.

fixes #625

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
