### PR TITLE
Cleanup

### DIFF
--- a/pulp-glue/pulp_glue/ansible/context.py
+++ b/pulp-glue/pulp_glue/ansible/context.py
@@ -11,7 +11,6 @@ from pulp_glue.common.context import (
     registered_repository_contexts,
 )
 from pulp_glue.common.i18n import get_translation
-from pulp_glue.common.openapi import UploadsMap
 
 translation = get_translation(__name__)
 _ = translation.gettext
@@ -48,15 +47,12 @@ class PulpAnsibleCollectionVersionSignatureContext(PulpContentContext):
         self,
         body: EntityDefinition,
         parameters: Optional[Mapping[str, Any]] = None,
-        uploads: Optional[UploadsMap] = None,
         non_blocking: bool = False,
     ) -> Any:
         self.pulp_ctx.needs_plugin(
             PluginRequirement("ansible", min="0.13.0", feature=_("collection version creation"))
         )
-        return super().create(
-            body=body, parameters=parameters, uploads=uploads, non_blocking=non_blocking
-        )
+        return super().create(body=body, parameters=parameters, non_blocking=non_blocking)
 
 
 class PulpAnsibleDistributionContext(PulpDistributionContext):

--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -9,7 +9,7 @@ from packaging.version import parse as parse_version
 from requests import HTTPError
 
 from pulp_glue.common.i18n import get_translation
-from pulp_glue.common.openapi import OpenAPI, OpenAPIError, UploadsMap
+from pulp_glue.common.openapi import OpenAPI, OpenAPIError
 
 translation = get_translation(__name__)
 _ = translation.gettext
@@ -181,7 +181,6 @@ class PulpContext:
         non_blocking: bool = False,
         parameters: Optional[Dict[str, Any]] = None,
         body: Optional[EntityDefinition] = None,
-        uploads: Optional[UploadsMap] = None,
         validate_body: bool = True,
     ) -> Any:
         """
@@ -194,17 +193,6 @@ class PulpContext:
             parameters = preprocess_payload(parameters)
         if body is not None:
             body = preprocess_payload(body)
-        # ---- SNIP ----
-        # In the future we want everything as part of the body.
-        if uploads:
-            self.echo(
-                _("Deprecated use of 'uploads' for operation '{operation_id}'").format(
-                    operation_id=operation_id
-                )
-            )
-            body = body or {}
-            body.update(uploads)
-        # ---- SNIP ----
         try:
             result = self.api.call(
                 operation_id,
@@ -504,7 +492,6 @@ class PulpEntityContext:
         non_blocking: bool = False,
         parameters: Optional[Dict[str, Any]] = None,
         body: Optional[EntityDefinition] = None,
-        uploads: Optional[UploadsMap] = None,
         validate_body: bool = True,
     ) -> Any:
         operation_id: str = (
@@ -515,7 +502,6 @@ class PulpEntityContext:
             non_blocking=non_blocking,
             parameters=parameters,
             body=body,
-            uploads=uploads,
             validate_body=validate_body,
         )
 
@@ -585,7 +571,6 @@ class PulpEntityContext:
         self,
         body: EntityDefinition,
         parameters: Optional[Mapping[str, Any]] = None,
-        uploads: Optional[UploadsMap] = None,
         non_blocking: bool = False,
     ) -> Any:
         _parameters = self.scope
@@ -597,7 +582,6 @@ class PulpEntityContext:
             "create",
             parameters=_parameters,
             body=body,
-            uploads=uploads,
             non_blocking=non_blocking,
         )
         if not non_blocking and result["pulp_href"].startswith(self.pulp_ctx.api_path + "tasks/"):
@@ -609,13 +593,8 @@ class PulpEntityContext:
         href: Optional[str] = None,
         body: Optional[EntityDefinition] = None,
         parameters: Optional[Mapping[str, Any]] = None,
-        uploads: Optional[UploadsMap] = None,
         non_blocking: bool = False,
     ) -> Any:
-        # Workaround for plugins that do not have ID_PREFIX in place
-        if hasattr(self, "UPDATE_ID") and not hasattr(self, "PARTIAL_UPDATE_ID"):
-            self.PARTIAL_UPDATE_ID = getattr(self, "UPDATE_ID")
-        # ----------------------------------------------------------
         _parameters = {self.HREF: href or self.pulp_href}
         if parameters:
             _parameters.update(parameters)
@@ -625,7 +604,6 @@ class PulpEntityContext:
             "partial_update",
             parameters=_parameters,
             body=body,
-            uploads=uploads,
             non_blocking=non_blocking,
         )
 

--- a/pulp-glue/pulp_glue/common/openapi.py
+++ b/pulp-glue/pulp_glue/common/openapi.py
@@ -6,7 +6,7 @@ import datetime
 import json
 import os
 from io import BufferedReader
-from typing import IO, Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
+from typing import IO, Any, Callable, Dict, List, Optional, Tuple, Union
 from urllib.parse import urljoin
 
 import requests
@@ -19,7 +19,6 @@ translation = get_translation(__name__)
 _ = translation.gettext
 
 UploadType = Union[bytes, IO[bytes]]
-UploadsMap = Mapping[str, UploadType]
 
 SAFE_METHODS = ["GET", "HEAD", "OPTIONS"]
 ISO_DATE_FORMAT = "%Y-%m-%d"

--- a/pulp-glue/pulp_glue/core/context.py
+++ b/pulp-glue/pulp_glue/core/context.py
@@ -12,7 +12,6 @@ from pulp_glue.common.context import (
     PulpException,
 )
 from pulp_glue.common.i18n import get_translation
-from pulp_glue.common.openapi import UploadsMap
 
 translation = get_translation(__name__)
 _ = translation.gettext
@@ -137,7 +136,6 @@ class PulpGroupPermissionContext(PulpEntityContext):
         non_blocking: bool = False,
         parameters: Optional[Dict[str, Any]] = None,
         body: Optional[Dict[str, Any]] = None,
-        uploads: Optional[UploadsMap] = None,
         validate_body: bool = False,
     ) -> Any:
         """Workaroud because the openapi spec for GroupPermissions has always been broken.
@@ -150,7 +148,6 @@ class PulpGroupPermissionContext(PulpEntityContext):
             non_blocking=non_blocking,
             parameters=parameters,
             body=body,
-            uploads=uploads,
             validate_body=validate_body,
         )
 


### PR DESCRIPTION
* Remove dead code for a workaround to operation ids that did not do anything anymore.
* Remove the deprecated uploads field from the call interfaces. Files should be specifies in the body argument anyway.

[noissue]

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
