### PR TITLE
Fix schema patching for pulpcore>=3.23,<3.30

### DIFF
--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -190,7 +190,7 @@ class PulpContext:
                             parameter["schema"] = {"type": "array", "items": {"type": "string"}}
         if self.has_plugin(PluginRequirement("core", specifier=">=3.23,<3.30.0")):
             operation = api_spec["paths"]["{upstream_pulp_href}replicate/"]["post"]
-            operation.pop("requestBody")
+            operation.pop("requestBody", None)
         if self.has_plugin(PluginRequirement("file", specifier=">=1.10.0,<1.11.0")):
             operation = api_spec["paths"]["{file_file_alternate_content_source_href}refresh/"][
                 "post"


### PR DESCRIPTION
As a part of my quest to fix the oci-images CI, I have discovered that recent schema fixes has broken the CLI when performing patching. This should make it more resilient. 
