### PR TITLE
Improves the replicate command test

### DIFF
--- a/tests/scripts/pulpcore/test_upstream_pulp.sh
+++ b/tests/scripts/pulpcore/test_upstream_pulp.sh
@@ -10,13 +10,13 @@ cleanup() {
 }
 trap cleanup EXIT
 
-expect_succ pulp upstream-pulp create --name "cli_test_upstream_pulp" --base-url "$PULP_BASE_URL" --api-root "/pulp/"
+expect_succ pulp upstream-pulp create --name "cli_test_upstream_pulp" --base-url "$PULP_BASE_URL" --api-root "/123/"
 expect_succ pulp upstream-pulp show --upstream-pulp "cli_test_upstream_pulp"
 expect_succ pulp upstream-pulp list
 expect_succ pulp upstream-pulp update --id "cli_test_upstream_pulp" --pulp-label-select "doesnotexist"
 
-# Without credentials there is not much we can do...
+# Without credentials and a wrong API root, there is not much we can do...
 # Also this is a real dangerous command, deleting all existing repositories.
-#expect_fail pulp upstream-pulp replicate --id "cli_test_upstream_pulp"
+expect_fail pulp upstream-pulp replicate --id "cli_test_upstream_pulp"
 
 expect_succ pulp upstream-pulp destroy --id "cli_test_upstream_pulp"


### PR DESCRIPTION
When the tests are run in pulpcore or plugin GitHub repos, there is a .netrc file present so the replicate task succeeds. Providing a bad API root ensures that the task always fails.
