### PR TITLE
Fixed crashing pulp domain

### DIFF
--- a/CHANGES/769.bugfix
+++ b/CHANGES/769.bugfix
@@ -1,0 +1,1 @@
+Fixed a crash in `pulp domain` when a default value for `--domain` was provided in the config file.

--- a/pulpcore/cli/core/domain.py
+++ b/pulpcore/cli/core/domain.py
@@ -21,7 +21,9 @@ translation = get_translation(__name__)
 _ = translation.gettext
 
 
-@pulp_group()
+# We need to override the default_map, because we may read a default value for the `--domain`
+# option from the config file that will collide here.
+@pulp_group(name="domain", context_settings={"default_map": {}})
 @pass_pulp_context
 @click.pass_context
 def domain(ctx: click.Context, pulp_ctx: PulpContext) -> None:


### PR DESCRIPTION
Providing a default value for --domain lead to the domain subcommand group getting an invalid default_map.

fixes #769

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
