### PR TITLE
Fix listing subcommands

### DIFF
--- a/CHANGES/781.bugfix
+++ b/CHANGES/781.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where not all commands of a command group were listed in the help and available to the auto-completion.

--- a/pulpcore/cli/common/generic.py
+++ b/pulpcore/cli/common/generic.py
@@ -217,25 +217,27 @@ class PulpGroup(PulpCommand, click.Group):
     def get_command(self, ctx: click.Context, cmd_name: str) -> t.Optional[click.Command]:
         # Overwriting this removes the command from the help message and from being callable
         cmd = super().get_command(ctx, cmd_name)
-        if isinstance(cmd, (PulpCommand, PulpGroup)):
-            if cmd.allowed_with_contexts is not None:
-                if not isinstance(ctx.obj, cmd.allowed_with_contexts):
-                    raise IncompatibleContext(
-                        _("The subcommand '{name}' is not available in this context.").format(
-                            name=cmd.name
-                        )
-                    )
+        if (
+            isinstance(cmd, (PulpCommand, PulpGroup))
+            and cmd.allowed_with_contexts is not None
+            and not isinstance(ctx.obj, cmd.allowed_with_contexts)
+        ):
+            raise IncompatibleContext(
+                _("The subcommand '{name}' is not available in this context.").format(name=cmd.name)
+            )
         return cmd
 
     def list_commands(self, ctx: click.Context) -> t.List[str]:
         commands_filtered_by_context = []
 
         for name, cmd in self.commands.items():
-            if isinstance(cmd, (PulpCommand, PulpGroup)):
-                if cmd.allowed_with_contexts is None or isinstance(
-                    ctx.obj, cmd.allowed_with_contexts
-                ):
-                    commands_filtered_by_context.append(name)
+            if (
+                isinstance(cmd, (PulpCommand, PulpGroup))
+                and cmd.allowed_with_contexts is not None
+                and not isinstance(ctx.obj, cmd.allowed_with_contexts)
+            ):
+                continue
+            commands_filtered_by_context.append(name)
 
         return sorted(commands_filtered_by_context)
 


### PR DESCRIPTION
This fixes the help pages and auto-completion missing subcommands not inherited from PulpCommand/PulpGroup.

fixes #781

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
