### PR TITLE
Rpm repo config won't be generated by default with 3.23+

### DIFF
--- a/pulp-glue/pulp_glue/common/openapi.py
+++ b/pulp-glue/pulp_glue/common/openapi.py
@@ -606,6 +606,7 @@ class OpenAPI:
         try:
             response: requests.Response = self._session.send(request)
         except requests.TooManyRedirects as e:
+            assert e.response is not None
             raise OpenAPIError(
                 _("Received redirect to '{url}'. Please check your CLI configuration.").format(
                     url=e.response.headers["location"]

--- a/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
+++ b/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
@@ -49,7 +49,10 @@ expect_succ pulp rpm distribution create --name "cli_test_rpm_distro" \
   --base-path "cli_test_rpm_distro" \
   --publication "$PUBLICATION_HREF"
 DISTRIBUTION_BASE_URL=$(echo "$OUTPUT" | jq -r .base_url)
-expect_succ curl "$curl_opt" --head --fail "${DISTRIBUTION_BASE_URL}config.repo"
+if pulp debug has-plugin --name "rpm" --specifier "<3.23.0.dev"
+then
+  expect_succ curl "$curl_opt" --head --fail "${DISTRIBUTION_BASE_URL}config.repo"
+fi
 
 expect_succ pulp rpm repository version list --repository "cli_test_rpm_repository"
 expect_succ pulp rpm repository version repair --repository "cli_test_rpm_repository" --version 1


### PR DESCRIPTION
[noissue]

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
