### PR TITLE
Skip some tests because rpm sync fails

### DIFF
--- a/tests/scripts/pulp_rpm/test_acs.sh
+++ b/tests/scripts/pulp_rpm/test_acs.sh
@@ -5,6 +5,9 @@
 
 pulp debug has-plugin --name "rpm" --min-version "3.18.0" || exit 23
 
+# This container seems to have issues with the compression format of the fixture.
+pulp debug has-plugin --name "rpm" --specifier "==3.20.0" && pulp debug has-plugin --name "core" --specifier "==3.23.21" && exit 23
+
 acs_remote="cli_test_rpm_acs_remote"
 acs="cli_test_acs"
 

--- a/tests/scripts/pulp_rpm/test_content.sh
+++ b/tests/scripts/pulp_rpm/test_content.sh
@@ -5,6 +5,9 @@
 
 pulp debug has-plugin --name "rpm" || exit 23
 
+# This container seems to have issues with the compression format of the fixture.
+pulp debug has-plugin --name "rpm" --specifier "==3.20.0" && pulp debug has-plugin --name "core" --specifier "==3.23.21" && exit 23
+
 TEST_ADVISORY="$(dirname "$(realpath "$0")")"/test_advisory.json
 RPM_FILENAME="lemon-0-1.noarch.rpm"
 RPM2_FILENAME="icecubes-2-3.noarch.rpm"


### PR DESCRIPTION
For some reason rpm sync fails in the pulpcore 3.23.21 container (pulp_rpm 3.20.0). It claims that it cannot autodetect or decompress zstd. I see no way fixing this fom this side, so I am skipping these tests for those versions.

[noissue]

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
