### PR TITLE
Remove sqlite-metadata option from `rpm update` cmd

### DIFF
--- a/CHANGES/831.removal
+++ b/CHANGES/831.removal
@@ -1,0 +1,1 @@
+Marked option `--sqlite-metadata` on `pulp rpm repository update/create` unavailable for `pulp_rpm>=3.25.0`, as it was removed there.

--- a/CHANGES/pulp-glue/831.removal
+++ b/CHANGES/pulp-glue/831.removal
@@ -1,0 +1,1 @@
+Added version restriction to prevent the use of `sqlite_metadata` attribute on Repository and Publication contexts for `pulp_rpm>=3.25.0`.

--- a/pulp-glue/pulp_glue/rpm/context.py
+++ b/pulp-glue/pulp_glue/rpm/context.py
@@ -211,6 +211,15 @@ class PulpRpmPublicationContext(PulpPublicationContext):
                     feature=_("customization of the config.repo file"),
                 )
             )
+        if "sqlite_metadata" in body:
+            self.pulp_ctx.needs_plugin(
+                PluginRequirement(
+                    "rpm",
+                    specifier=">=3.25.0",
+                    inverted=True,
+                    feature=_("sqlite_metadata generation"),
+                )
+            )
         return body
 
 
@@ -279,6 +288,15 @@ class PulpRpmRepositoryContext(PulpRepositoryContext):
                     "rpm",
                     specifier=">=3.24.0",
                     feature=_("customization of the config.repo file"),
+                )
+            )
+        if "sqlite_metadata" in body:
+            self.pulp_ctx.needs_plugin(
+                PluginRequirement(
+                    "rpm",
+                    specifier=">=3.25.0",
+                    inverted=True,
+                    feature=_("sqlite_metadata generation"),
                 )
             )
         return body

--- a/pulpcore/cli/rpm/repository.py
+++ b/pulpcore/cli/rpm/repository.py
@@ -167,7 +167,14 @@ update_options = [
             on the repodata."""
         ),
     ),
-    click.option("--sqlite-metadata/--no-sqlite-metadata", default=None),
+    click.option(
+        "--sqlite-metadata/--no-sqlite-metadata",
+        default=None,
+        help=_(
+            """DEPRECATED: An option specifying whether Pulp should generate SQLite metadata.
+            Unavailable for pulp_rpm>=3.25.0"""
+        ),
+    ),
     pulp_option(
         "--autopublish/--no-autopublish",
         needs_plugins=[PluginRequirement("rpm", specifier=">=3.12.0")],

--- a/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
+++ b/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
@@ -42,6 +42,14 @@ expect_succ pulp rpm repository update --repository "cli_test_rpm_repository" --
 expect_succ pulp rpm repository show --repository "cli_test_rpm_repository"
 test "$(echo "$OUTPUT" | jq -r '.description')" = "null"
 
+# sqlite metadata removal from pulp_rpm (pulp/pulp_rpm#3328)
+if pulp debug has-plugin --name "rpm" --specifier "<3.25.0"
+then
+  expect_succ pulp rpm repository update --name "cli_test_rpm_repository" --no-sqlite-metadata
+else
+  expect_fail pulp rpm repository update --name "cli_test_rpm_repository" --no-sqlite-metadata
+fi
+
 if pulp debug has-plugin --name "rpm" --specifier ">=3.24.0"
 then
 expect_succ pulp rpm repository create --name "cli_test_rpm_repository2" --repo-config "@repo_config.json"


### PR DESCRIPTION
Removed from "pulp rpm repository update" command. The reason is that it was phased out from pulp_rpm plugin. https://github.com/pulp/pulp_rpm/issues/2457

fixes: #831

Review Checklist:
- [x] An issue is properly linked. [feature and bugfix only]
- [x] Tests are present or not feasible.
- [x] Commits are split in a logical way (not historically).
