### PR TITLE
gpgcheck integer instead of choice

### DIFF
--- a/CHANGES/677.bugfix
+++ b/CHANGES/677.bugfix
@@ -1,0 +1,1 @@
+Arguments --gpgcheck and --repo-gpgcheck in creating a rpm repository no longer fail to convert to integer.

--- a/pulpcore/cli/rpm/repository.py
+++ b/pulpcore/cli/rpm/repository.py
@@ -82,6 +82,12 @@ def _content_callback(ctx: click.Context, param: click.Parameter, value: Any) ->
 CONTENT_LIST_SCHEMA = s.Schema([{"pulp_href": str}])
 
 
+def choice_to_int_callback(ctx: click.Context, param: click.Parameter, value: Any) -> Optional[int]:
+    if value:
+        return int(value)
+    return None
+
+
 @pulp_group()
 @click.option(
     "-t",
@@ -146,6 +152,7 @@ update_options = [
     click.option(
         "--gpgcheck",
         type=click.Choice(("0", "1")),
+        callback=choice_to_int_callback,
         help=_(
             """DEPRECATED:Option specifying whether a client should perform a GPG signature check
             on packages."""
@@ -154,6 +161,7 @@ update_options = [
     click.option(
         "--repo-gpgcheck",
         type=click.Choice(("0", "1")),
+        callback=choice_to_int_callback,
         help=_(
             """DEPRECATED:Option specifying whether a client should perform a GPG signature check
             on the repodata."""

--- a/tests/scripts/pulp_rpm/gpgcheck_test.sh
+++ b/tests/scripts/pulp_rpm/gpgcheck_test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# shellcheck source=tests/scripts/config.source
+. "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
+
+pulp debug has-plugin --name "rpm" --max-version "3.23.0" || exit 23
+
+cleanup () {
+  pulp rpm repository destroy --name "cli-repo-gpgcheck" || true
+}
+trap cleanup EXIT
+
+expect succ pulp rpm repository create --name "cli-repo-gpgcheck" --gpgcheck 1 --repo-gpgcheck 1
+expect succ pulp rpm repository show --name "cli-repo-gpgcheck"
+test "$(echo "$OUTPUT" | jq -r '.gpgcheck')" = 1
+test "$(echo "$OUTPUT" | jq -r '.repo_gpgcheck')" = 1
+
+expect succ pulp rpm repository update --name "cli-repo-gpgcheck" --gpgcheck 0 --repo-gpgcheck 0
+expect succ pulp rpm repository show --name "cli-repo-gpgcheck"
+test "$(echo "$OUTPUT" | jq -r '.gpgcheck')" = 0
+test "$(echo "$OUTPUT" | jq -r '.repo_gpgcheck')" = 0


### PR DESCRIPTION
Arguments --gpgcheck and --repo-gpgcheck in creating a rpm repository no longer fail to convert to integer.

closes #677
