### PR TITLE
Repository version user-entered options order fix

### DIFF
--- a/CHANGES/650.bugfix
+++ b/CHANGES/650.bugfix
@@ -1,0 +1,1 @@
+User-entered order of parameters no longer matters for repository version commands.

--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -675,9 +675,8 @@ class PulpEntityContext:
             self.pulp_ctx.needs_plugin(plugin_requirement)
 
         self._entity = None
-        if pulp_href is None:
-            self._entity_lookup = entity or {}
-        else:
+        self._entity_lookup = entity or {}
+        if pulp_href is not None:
             self.pulp_href = pulp_href
 
     def call(
@@ -1159,6 +1158,21 @@ class PulpRepositoryVersionContext(PulpEntityContext):
             return {}
         else:
             return {self.repository_ctx.HREF: self.repository_ctx.pulp_href}
+
+    @property
+    def entity(self) -> EntityDefinition:
+        if (
+            self._entity is None
+            and "number" in self._entity_lookup.keys()
+            and self._entity_lookup.get("number") is None
+        ):
+            self.pulp_href = self.repository_ctx.entity["latest_version_href"]
+        return super().entity
+
+    @entity.setter
+    def entity(self, value: Optional[EntityDefinition]) -> None:
+        # ignore needed due to a bug regarding overriding property setter in mypy
+        PulpEntityContext.entity.fset(self, value)  # type: ignore[attr-defined]
 
     def repair(self, href: Optional[str] = None) -> Any:
         """

--- a/pulpcore/cli/common/generic.py
+++ b/pulpcore/cli/common/generic.py
@@ -414,14 +414,9 @@ def href_callback(
 def _version_callback(
     ctx: click.Context, param: click.Parameter, value: t.Optional[int]
 ) -> t.Optional[int]:
-    entity_ctx = ctx.find_object(PulpEntityContext)
-    assert entity_ctx is not None
-    repository_ctx = ctx.find_object(PulpRepositoryContext)
-    assert repository_ctx is not None
-    if value is not None:
-        entity_ctx.pulp_href = f"{repository_ctx.entity['versions_href']}{value}/"
-    else:
-        entity_ctx.pulp_href = repository_ctx.entity["latest_version_href"]
+    repository_version_ctx = ctx.find_object(PulpRepositoryVersionContext)
+    assert repository_version_ctx is not None
+    repository_version_ctx.entity = {"number": value}
     return value
 
 

--- a/tests/scripts/pulp_file/test_sync.sh
+++ b/tests/scripts/pulp_file/test_sync.sh
@@ -46,7 +46,7 @@ expect_succ pulp file repository version repair --repository "cli_test_file_repo
 test "$(echo "$OUTPUT" | jq -r '.state')" = "completed"
 
 # Delete version again
-expect_succ pulp file repository version destroy --repository "cli_test_file_repository" --version 1
+expect_succ pulp file repository version destroy --version 1 --repository "cli_test_file_repository"
 
 # Test autopublish
 expect_succ pulp file repository create --name "$autopublish_repo" --remote "cli_test_file_remote" --autopublish


### PR DESCRIPTION
The order in which the user enters options (--version, --repository, ..) no longer matters for
'pulp <plugin> repository version' commands, since all API calls are now deferred to after the
options' callbacks are processed.

closes #650

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
