### PR TITLE
Remove pkg_resources

### DIFF
--- a/.ci/scripts/collect_changes.py
+++ b/.ci/scripts/collect_changes.py
@@ -4,7 +4,7 @@ import re
 
 import toml
 from git import GitCommandError, Repo
-from pkg_resources import parse_version
+from packaging.version import parse as parse_version
 
 # Read Towncrier settings
 tc_settings = toml.load("pyproject.toml")["tool"]["towncrier"]

--- a/.github/workflows/collect_changes.yml
+++ b/.github/workflows/collect_changes.yml
@@ -20,7 +20,7 @@ jobs:
           git config user.email pulp-infra@redhat.com
       - name: Collect changes
         run: |
-          pip install GitPython toml
+          pip install GitPython packaging toml
           python3 .ci/scripts/collect_changes.py
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5

--- a/CHANGES/+pipx.doc
+++ b/CHANGES/+pipx.doc
@@ -1,0 +1,1 @@
+Added information how to use pipx for installation.

--- a/CHANGES/865.bugfix
+++ b/CHANGES/865.bugfix
@@ -1,0 +1,1 @@
+Remove dependency on `pkg_resources` that failed some installations but is deprecated anyway.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,24 @@ pulp status
 The pulp-cli package can be installed from a variety of sources.
 After installing, see the next section on how to configure pulp-cli.
 
-## From PyPI
+## Using pipx
+
+To install with `pipx` run:
+```bash
+pipx install pulp-cli
+```
+
+You can add optional dependencies in the usual way.
+```bash
+pipx install pulp-cli[pygments,shell]
+```
+
+Additional plugins need to be injected into the apps virtual environment like this:
+```bash
+pipx inject pulp-cli pulp-cli-deb
+```
+
+## From PyPI using pip
 
 To install with minimal dependencies:
 ```bash

--- a/pulp-glue/pulp_glue/ansible/context.py
+++ b/pulp-glue/pulp_glue/ansible/context.py
@@ -11,7 +11,7 @@ from pulp_glue.common.context import (
 )
 from pulp_glue.common.i18n import get_translation
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulp-glue/pulp_glue/certguard/context.py
+++ b/pulp-glue/pulp_glue/certguard/context.py
@@ -1,7 +1,7 @@
 from pulp_glue.common.context import PluginRequirement, PulpContentGuardContext
 from pulp_glue.common.i18n import get_translation
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -12,7 +12,7 @@ from requests import HTTPError
 from pulp_glue.common.i18n import get_translation
 from pulp_glue.common.openapi import OpenAPI, OpenAPIError
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 DEFAULT_LIMIT = 25

--- a/pulp-glue/pulp_glue/common/i18n.py
+++ b/pulp-glue/pulp_glue/common/i18n.py
@@ -1,9 +1,15 @@
 import gettext
+import sys
 from functools import lru_cache
 
-import pkg_resources
+if sys.version_info >= (3, 9):
+    from importlib.resources import files
+else:
+    from importlib_resources import files
 
 
+# Need to call lru_cache() before using it as a decorator for python 3.7 compatibility
+@lru_cache(maxsize=None)
 def get_translation(name: str) -> gettext.NullTranslations:
     """
     Return a translations object for a certain import path.
@@ -19,15 +25,9 @@ def get_translation(name: str) -> gettext.NullTranslations:
         ```
         from pulp_glue.common.i18n import get_translation
 
-        translation = get_translation(__name__)
+        translation = get_translation(__package__)
         _ = translation.gettext
         ```
     """
-    localedir = pkg_resources.resource_filename(name, "locale")
-    return _get_translation_for_domain("messages", localedir)
-
-
-# Need to call lru_cache() before using it as a decorator for python 3.7 compatibility
-@lru_cache(maxsize=None)
-def _get_translation_for_domain(domain: str, localedir: str) -> gettext.NullTranslations:
-    return gettext.translation(domain, localedir=localedir, fallback=True)
+    localedir = files(name) / "locale"
+    return gettext.translation("messages", localedir=str(localedir), fallback=True)

--- a/pulp-glue/pulp_glue/common/openapi.py
+++ b/pulp-glue/pulp_glue/common/openapi.py
@@ -16,7 +16,7 @@ import urllib3
 from pulp_glue.common import __version__
 from pulp_glue.common.i18n import get_translation
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 UploadType = Union[bytes, IO[bytes]]

--- a/pulp-glue/pulp_glue/container/context.py
+++ b/pulp-glue/pulp_glue/container/context.py
@@ -12,7 +12,7 @@ from pulp_glue.common.context import (
 )
 from pulp_glue.common.i18n import get_translation
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulp-glue/pulp_glue/core/context.py
+++ b/pulp-glue/pulp_glue/core/context.py
@@ -14,7 +14,7 @@ from pulp_glue.common.context import (
 )
 from pulp_glue.common.i18n import get_translation
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulp-glue/pulp_glue/file/context.py
+++ b/pulp-glue/pulp_glue/file/context.py
@@ -16,7 +16,7 @@ from pulp_glue.common.i18n import get_translation
 from pulp_glue.common.openapi import OpenAPI
 from pulp_glue.core.context import PulpArtifactContext
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulp-glue/pulp_glue/python/context.py
+++ b/pulp-glue/pulp_glue/python/context.py
@@ -12,7 +12,7 @@ from pulp_glue.common.context import (
 from pulp_glue.common.i18n import get_translation
 from pulp_glue.common.openapi import OpenAPI
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulp-glue/pulp_glue/rpm/context.py
+++ b/pulp-glue/pulp_glue/rpm/context.py
@@ -17,7 +17,7 @@ from pulp_glue.common.context import (
 )
 from pulp_glue.common.i18n import get_translation
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulp-glue/pyproject.toml
+++ b/pulp-glue/pyproject.toml
@@ -13,18 +13,19 @@ authors = [
   {name = "Pulp Team", email = "pulp-list@redhat.com"},
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
-    "Environment :: Other Environment",
-    "Intended Audience :: Developers",
-    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
-    "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3",
-    "Topic :: System :: Software Distribution",
-    "Typing :: Typed",
+  "Development Status :: 4 - Beta",
+  "Environment :: Other Environment",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Topic :: System :: Software Distribution",
+  "Typing :: Typed",
 ]
 dependencies = [
-    "packaging>=20.0,<24",
-    "requests>=2.24.0,<2.32",
+  "packaging>=20.0,<24",
+  "requests>=2.24.0,<2.32",
+  "importlib_resources>=5.4,<6.2;python_version<'3.9'",
 ]
 
 [project.urls]

--- a/pulp_cli/__init__.py
+++ b/pulp_cli/__init__.py
@@ -1,8 +1,13 @@
+import sys
 from types import ModuleType
 from typing import Any, Dict, Optional
 
 import click
-import pkg_resources
+
+if sys.version_info >= (3, 10):
+    from importlib.metadata import entry_points
+else:
+    from importlib_metadata import entry_points
 
 __version__ = "0.23.0.dev"
 _main: Optional[click.Group] = None
@@ -16,7 +21,7 @@ def load_plugins() -> click.Group:
     # https://packaging.python.org/guides/creating-and-discovering-plugins/#using-package-metadata
     discovered_plugins: Dict[str, ModuleType] = {
         entry_point.name: entry_point.load()
-        for entry_point in pkg_resources.iter_entry_points("pulp_cli.plugins")
+        for entry_point in entry_points(group="pulp_cli.plugins")
     }
     _main = discovered_plugins["common"].main
     assert isinstance(_main, click.Group)

--- a/pulpcore/cli/ansible/__init__.py
+++ b/pulpcore/cli/ansible/__init__.py
@@ -9,7 +9,7 @@ from pulpcore.cli.ansible.remote import remote
 from pulpcore.cli.ansible.repository import repository
 from pulpcore.cli.common.generic import pulp_group
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/ansible/content.py
+++ b/pulpcore/cli/ansible/content.py
@@ -25,7 +25,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/ansible/distribution.py
+++ b/pulpcore/cli/ansible/distribution.py
@@ -29,7 +29,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/ansible/remote.py
+++ b/pulpcore/cli/ansible/remote.py
@@ -28,7 +28,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/ansible/repository.py
+++ b/pulpcore/cli/ansible/repository.py
@@ -47,7 +47,7 @@ from pulpcore.cli.common.generic import (
 )
 from pulpcore.cli.core.generic import task_command
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/common/__init__.py
+++ b/pulpcore/cli/common/__init__.py
@@ -20,7 +20,7 @@ from pulpcore.cli.common.generic import PulpCLIContext, pulp_group
 
 __version__ = "0.23.0.dev"
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/common/acs.py
+++ b/pulpcore/cli/common/acs.py
@@ -22,7 +22,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/common/config.py
+++ b/pulpcore/cli/common/config.py
@@ -8,7 +8,7 @@ from pulp_glue.common.i18n import get_translation
 
 from pulpcore.cli.common.generic import pulp_group
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 _T = TypeVar("_T")

--- a/pulpcore/cli/common/debug.py
+++ b/pulpcore/cli/common/debug.py
@@ -12,7 +12,7 @@ from pulpcore.cli.common.generic import (
     pulp_group,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/common/generic.py
+++ b/pulpcore/cli/common/generic.py
@@ -37,7 +37,7 @@ else:
     PYGMENTS = True
     PYGMENTS_STYLE = "solarized-dark"
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/container/__init__.py
+++ b/pulpcore/cli/container/__init__.py
@@ -10,7 +10,7 @@ from pulpcore.cli.container.namespace import namespace
 from pulpcore.cli.container.remote import remote
 from pulpcore.cli.container.repository import repository
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/container/distribution.py
+++ b/pulpcore/cli/container/distribution.py
@@ -34,7 +34,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/container/namespace.py
+++ b/pulpcore/cli/container/namespace.py
@@ -16,7 +16,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/container/remote.py
+++ b/pulpcore/cli/container/remote.py
@@ -22,7 +22,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/container/repository.py
+++ b/pulpcore/cli/container/repository.py
@@ -39,7 +39,7 @@ from pulpcore.cli.common.generic import (
 from pulpcore.cli.container.content import show_options
 from pulpcore.cli.core.generic import task_command
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 VALID_TAG_REGEX = r"^[A-Za-z0-9][A-Za-z0-9._-]*$"
 

--- a/pulpcore/cli/core/access_policy.py
+++ b/pulpcore/cli/core/access_policy.py
@@ -16,7 +16,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/artifact.py
+++ b/pulpcore/cli/core/artifact.py
@@ -17,7 +17,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/content.py
+++ b/pulpcore/cli/core/content.py
@@ -4,7 +4,7 @@ from pulp_glue.common.i18n import get_translation
 
 from pulpcore.cli.common.generic import PulpCLIContext, list_command, pass_pulp_context, pulp_group
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/content_guard.py
+++ b/pulpcore/cli/core/content_guard.py
@@ -25,7 +25,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/domain.py
+++ b/pulpcore/cli/core/domain.py
@@ -17,7 +17,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/export.py
+++ b/pulpcore/cli/core/export.py
@@ -20,7 +20,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 pass_export_context = click.make_pass_decorator(PulpExportContext)

--- a/pulpcore/cli/core/exporter.py
+++ b/pulpcore/cli/core/exporter.py
@@ -17,7 +17,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 pass_exporter_context = click.make_pass_decorator(PulpExporterContext)

--- a/pulpcore/cli/core/generic.py
+++ b/pulpcore/cli/core/generic.py
@@ -16,7 +16,7 @@ from pulpcore.cli.common.generic import (
     resource_option,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/group.py
+++ b/pulpcore/cli/core/group.py
@@ -31,7 +31,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 pass_group_context = click.make_pass_decorator(PulpGroupContext)

--- a/pulpcore/cli/core/importer.py
+++ b/pulpcore/cli/core/importer.py
@@ -15,7 +15,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 pass_importer_context = click.make_pass_decorator(PulpImporterContext)

--- a/pulpcore/cli/core/orphan.py
+++ b/pulpcore/cli/core/orphan.py
@@ -14,7 +14,7 @@ from pulpcore.cli.common.generic import (
     pulp_option,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/repository.py
+++ b/pulpcore/cli/core/repository.py
@@ -21,7 +21,7 @@ from pulpcore.cli.common.generic import (
     version_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/show.py
+++ b/pulpcore/cli/core/show.py
@@ -3,7 +3,7 @@ from pulp_glue.common.i18n import get_translation
 
 from pulpcore.cli.common.generic import PulpCLIContext, pass_pulp_context, pulp_command
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/signing_service.py
+++ b/pulpcore/cli/core/signing_service.py
@@ -12,7 +12,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/status.py
+++ b/pulpcore/cli/core/status.py
@@ -5,7 +5,7 @@ from pulp_glue.common.i18n import get_translation
 
 from pulpcore.cli.common.generic import PulpCLIContext, pass_pulp_context, pulp_command
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/task.py
+++ b/pulpcore/cli/core/task.py
@@ -24,7 +24,7 @@ from pulpcore.cli.common.generic import (
 )
 from pulpcore.cli.core.generic import task_filter
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/task_group.py
+++ b/pulpcore/cli/core/task_group.py
@@ -15,7 +15,7 @@ from pulpcore.cli.common.generic import (
     pulp_option,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/upload.py
+++ b/pulpcore/cli/core/upload.py
@@ -12,7 +12,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/upstream_pulp.py
+++ b/pulpcore/cli/core/upstream_pulp.py
@@ -17,7 +17,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 lookup_option = resource_lookup_option(

--- a/pulpcore/cli/core/user.py
+++ b/pulpcore/cli/core/user.py
@@ -22,7 +22,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/core/worker.py
+++ b/pulpcore/cli/core/worker.py
@@ -12,7 +12,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/file/__init__.py
+++ b/pulpcore/cli/file/__init__.py
@@ -12,7 +12,7 @@ from pulpcore.cli.file.publication import publication
 from pulpcore.cli.file.remote import remote
 from pulpcore.cli.file.repository import repository
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/file/content.py
+++ b/pulpcore/cli/file/content.py
@@ -19,7 +19,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/file/distribution.py
+++ b/pulpcore/cli/file/distribution.py
@@ -23,7 +23,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/file/publication.py
+++ b/pulpcore/cli/file/publication.py
@@ -16,7 +16,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/file/remote.py
+++ b/pulpcore/cli/file/remote.py
@@ -21,7 +21,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/file/repository.py
+++ b/pulpcore/cli/file/repository.py
@@ -45,7 +45,7 @@ from pulpcore.cli.common.generic import (
 )
 from pulpcore.cli.core.generic import task_command
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/migration/context.py
+++ b/pulpcore/cli/migration/context.py
@@ -3,7 +3,7 @@ from typing import Any, Optional
 from pulp_glue.common.context import PulpEntityContext
 from pulp_glue.common.i18n import get_translation
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/migration/plan.py
+++ b/pulpcore/cli/migration/plan.py
@@ -14,7 +14,7 @@ from pulpcore.cli.common.generic import (
 )
 from pulpcore.cli.migration.context import PulpMigrationPlanContext
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 pass_migration_plan_context = click.make_pass_decorator(PulpMigrationPlanContext)

--- a/pulpcore/cli/python/content.py
+++ b/pulpcore/cli/python/content.py
@@ -19,7 +19,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/python/distribution.py
+++ b/pulpcore/cli/python/distribution.py
@@ -28,7 +28,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/python/publication.py
+++ b/pulpcore/cli/python/publication.py
@@ -15,7 +15,7 @@ from pulpcore.cli.common.generic import (
     show_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/python/remote.py
+++ b/pulpcore/cli/python/remote.py
@@ -26,7 +26,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/python/repository.py
+++ b/pulpcore/cli/python/repository.py
@@ -40,7 +40,7 @@ from pulpcore.cli.common.generic import (
 )
 from pulpcore.cli.core.generic import task_command
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/rpm/__init__.py
+++ b/pulpcore/cli/rpm/__init__.py
@@ -13,7 +13,7 @@ from pulpcore.cli.rpm.publication import publication
 from pulpcore.cli.rpm.remote import remote
 from pulpcore.cli.rpm.repository import repository
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/rpm/content.py
+++ b/pulpcore/cli/rpm/content.py
@@ -35,7 +35,7 @@ from pulpcore.cli.common.generic import (
     type_option,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/rpm/distribution.py
+++ b/pulpcore/cli/rpm/distribution.py
@@ -24,7 +24,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 repository_option = resource_option(

--- a/pulpcore/cli/rpm/publication.py
+++ b/pulpcore/cli/rpm/publication.py
@@ -20,7 +20,7 @@ from pulpcore.cli.common.generic import (
 )
 from pulpcore.cli.rpm.common import CHECKSUM_CHOICES
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/rpm/remote.py
+++ b/pulpcore/cli/rpm/remote.py
@@ -21,7 +21,7 @@ from pulpcore.cli.common.generic import (
     update_command,
 )
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 

--- a/pulpcore/cli/rpm/repository.py
+++ b/pulpcore/cli/rpm/repository.py
@@ -46,7 +46,7 @@ from pulpcore.cli.common.generic import (
 from pulpcore.cli.core.generic import task_command
 from pulpcore.cli.rpm.common import CHECKSUM_CHOICES, LEGACY_CHECKSUM_CHOICES
 
-translation = get_translation(__name__)
+translation = get_translation(__package__)
 _ = translation.gettext
 
 SKIP_TYPES = ["srpm", "treeinfo"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "PyYAML>=5.3,<6.1",
   "schema>=0.7.5,<0.8",
   "toml>=0.10.2,<0.11",
+  "importlib_metadata>=4.8,<7.1;python_version<'3.10'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Replaces all uses of pkg_resources with importlib, because the former has been deprecated.

fixes #865

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
