### PR TITLE
Remove .dev from pulp_rpm 3.25.0 version specifiers

### DIFF
--- a/pulp-glue/pulp_glue/rpm/context.py
+++ b/pulp-glue/pulp_glue/rpm/context.py
@@ -215,7 +215,7 @@ class PulpRpmPublicationContext(PulpPublicationContext):
             self.pulp_ctx.needs_plugin(
                 PluginRequirement(
                     "rpm",
-                    specifier=">=3.25.0.dev",
+                    specifier=">=3.25.0",
                     inverted=True,
                     feature=_("sqlite_metadata generation"),
                 )
@@ -228,13 +228,13 @@ class PulpRpmPublicationContext(PulpPublicationContext):
             if metadata_checksum_type and metadata_checksum_type in disallowed_checksums:
                 self.pulp_ctx.needs_plugin(
                     PluginRequirement(
-                        "rpm", specifier=">=3.25.0.dev", inverted=True, feature=_("weak checksums")
+                        "rpm", specifier=">=3.25.0", inverted=True, feature=_("weak checksums")
                     )
                 )
             if package_checksum_type and package_checksum_type in disallowed_checksums:
                 self.pulp_ctx.needs_plugin(
                     PluginRequirement(
-                        "rpm", specifier=">=3.25.0.dev", inverted=True, feature=_("weak checksums")
+                        "rpm", specifier=">=3.25.0", inverted=True, feature=_("weak checksums")
                     )
                 )
         return body
@@ -311,7 +311,7 @@ class PulpRpmRepositoryContext(PulpRepositoryContext):
             self.pulp_ctx.needs_plugin(
                 PluginRequirement(
                     "rpm",
-                    specifier=">=3.25.0.dev",
+                    specifier=">=3.25.0",
                     inverted=True,
                     feature=_("sqlite_metadata generation"),
                 )
@@ -324,13 +324,13 @@ class PulpRpmRepositoryContext(PulpRepositoryContext):
             if metadata_checksum_type and metadata_checksum_type in disallowed_checksums:
                 self.pulp_ctx.needs_plugin(
                     PluginRequirement(
-                        "rpm", specifier=">=3.25.0.dev", inverted=True, feature=_("weak checksums")
+                        "rpm", specifier=">=3.25.0", inverted=True, feature=_("weak checksums")
                     )
                 )
             if package_checksum_type and package_checksum_type in disallowed_checksums:
                 self.pulp_ctx.needs_plugin(
                     PluginRequirement(
-                        "rpm", specifier=">=3.25.0.dev", inverted=True, feature=_("weak checksums")
+                        "rpm", specifier=">=3.25.0", inverted=True, feature=_("weak checksums")
                     )
                 )
 
@@ -338,7 +338,7 @@ class PulpRpmRepositoryContext(PulpRepositoryContext):
             self.pulp_ctx.needs_plugin(
                 PluginRequirement(
                     "rpm",
-                    specifier=">=3.25.0.dev",
+                    specifier=">=3.25.0",
                     feature=_("checksum_type"),
                 )
             )

--- a/pulpcore/cli/rpm/publication.py
+++ b/pulpcore/cli/rpm/publication.py
@@ -72,7 +72,7 @@ create_options = [
         help=_(
             "Option specifying the checksum type to use for package and metadata integrity checks."
         ),
-        needs_plugins=[PluginRequirement("rpm", specifier=">=3.25.0.dev")],
+        needs_plugins=[PluginRequirement("rpm", specifier=">=3.25.0")],
     ),
 ]
 publication.add_command(list_command(decorators=publication_filter_options + [repository_option]))

--- a/pulpcore/cli/rpm/repository.py
+++ b/pulpcore/cli/rpm/repository.py
@@ -164,7 +164,7 @@ update_options = [
         help=_(
             "Option specifying the checksum type to use for package and metadata integrity checks."
         ),
-        needs_plugins=[PluginRequirement("rpm", specifier=">=3.25.0.dev")],
+        needs_plugins=[PluginRequirement("rpm", specifier=">=3.25.0")],
     ),
     click.option(
         "--gpgcheck",

--- a/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
+++ b/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
@@ -43,7 +43,7 @@ expect_succ pulp rpm repository show --repository "cli_test_rpm_repository"
 test "$(echo "$OUTPUT" | jq -r '.description')" = "null"
 
 # sqlite metadata removal from pulp_rpm (pulp/pulp_rpm#3328)
-if pulp debug has-plugin --name "rpm" --specifier "<3.25.0.dev"
+if pulp debug has-plugin --name "rpm" --specifier "<3.25.0"
 then
   expect_succ pulp rpm repository update --name "cli_test_rpm_repository" --no-sqlite-metadata
 else
@@ -115,7 +115,7 @@ expect_succ pulp rpm repository sync --repository "cli_test_rpm_repository" --sy
 expect_succ pulp rpm repository sync --repository "cli_test_rpm_repository" --sync-policy mirror_content_only
 expect_fail pulp rpm repository sync --repository "cli_test_rpm_repository" --sync-policy foobar
 
-if pulp debug has-plugin --name "rpm" --specifier ">=3.25.0.dev"
+if pulp debug has-plugin --name "rpm" --specifier ">=3.25.0"
 then
   expect_succ pulp rpm publication create --repository "cli_test_rpm_repository" --checksum-type sha512
   expect_fail pulp rpm publication create --repository "cli_test_rpm_repository" --checksum-type sha1


### PR DESCRIPTION
This reverts commit e2a10a2b16b0a5d13129c06d367f3ed4d7e980b5.

[noissue]