### PR TITLE
Check for uniqueness on entity lookup

### DIFF
--- a/CHANGES/pulp-glue/894.bugfix
+++ b/CHANGES/pulp-glue/894.bugfix
@@ -1,0 +1,1 @@
+Added a missing check for uniqueness on entity lookup.


### PR DESCRIPTION
In case more than one entity is found for the specified search parameters, an exception is thrown. This does not validate the search parameters beforehand guaranteed to be a natual key set.

fixes #894

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
