### PR TITLE
Better separate between glue and cli in docs

### DIFF
--- a/CHANGES/+glue_docs_improvements.docs
+++ b/CHANGES/+glue_docs_improvements.docs
@@ -1,0 +1,1 @@
+Better separate the concepts of cli and glue in the architecture docs.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,46 +16,34 @@ If you are using the Pulp CLI and have written end-to-end steps for Pulp workflo
 
 ## Code Conventions
 
-If you are interested in contributing code, note that we have styling and formatting
-conventions for both the code and our PRs:
-* `pulp-cli` utilizes python type annotations and black and isort code formatting.
-  To run the auto-formatting features, execute `make black`.
-* To check for compliance, please, install lint requirements and run lint checks before committing changes:
-  ```
-  pip install -r lint_requirements.txt
-  make lint
-  ```
-  * This executes the following checks:
-    * shellcheck
-    * black
-    * isort
-    * flake8
-    * mypy
-* If your PR is in response to an open issue, add `fixes #<ISSUE-NUMBER>` as its own line
-in your commit message. If you do **not** have an issue, use `[noissue]`.
+If you are interested in contributing code,
+note that we have styling and formatting conventions for both the code and our PRs:
+
+- Code formatting is done with `isort` and `black`.
+
+- Static analysis is performed with `flake8`.
+
+- `pulp-cli` utilizes strict python type annotations, checked with `mypy`.
+
+- Shell scripts must pass `shellcheck`.
+
+- If your PR is in response to an open issue, add `fixes #<ISSUE-NUMBER>` as its own line in your commit message.
+  If you do **not** have an issue, use `[noissue]`.
 
 !!!note
 
-   PRs need to pass these checks before they can be merged.
+    PRs need to pass these checks before they can be merged.
+
+    We recommend running these before committing:
+    ```bash
+    pip install -r lint_requirements.txt  # setup, needed only once
+    make black  # reformatting with isort & black
+    make lint  # checking with shellcheck, isort, black, flake8 and mypy
+    make black lint  # both in one command
+    ```
 
 Also please follow [The seven rules of a great Git commit message](https://chris.beams.io/posts/git-commit/).
 And finally, for each new feature, we require corresponding tests.
-
-## Global Help Accessibility
-
-In order to be able to access every (sub-)commands help page,
-it is necessary that no code outside of the final performing command callback accesses the `api` property of the `PulpContext`.
-There are some facilities that perform lazy loading to help with that requirement.
-Those include:
-
-  - `PulpContext.api`: When accessed, the `api.json` file for the addressed server will be read or downloaded and processed.
-    Scheduled version checks will be reevaluated.
-  - `PulpContext.needs_version`: This function can be used at any time to declear that an operation needs a plugin in a version range.
-    The actual check will be performed, once `api` was accessed for the first time, or immediately afterwards.
-  - `PulpEntityContext.entity`: This property can be used to collect lookup attributes for entities by assigining dicts to it.
-    On read access, the entity lookup will be performed though the `api` property.
-  - `PulpEntityContext.pulp_href`: This property can be used to specify an entity by its URI.
-    It will be fetched from the server only at read access.
 
 ## Testing
 
@@ -70,7 +58,7 @@ configured in `tests/cli.toml`.
 
 To run tests:
 
-```
+```bash
 make test                           # all tests
 pytest -m pulp_file                 # tests for pulp_file
 pytest -m pulp_file -k test_remote  # run tests/scripts/pulp_file/test_remote.sh


### PR DESCRIPTION
The architecture page should properly introduce all sections of the codebase and state their respective purposes.

[noissue]

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
