### PR TITLE
Drop python 3.6 and 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,9 +21,9 @@ jobs:
             pulp_api_root: "/relocated/djnd/"
           - python: "3.11"
             image_tag: "latest"
-          - python: "3.6"
+          - python: "3.12"
             image_tag: "3.39"
-          - python: "3.7"
+          - python: "3.12"
             image_tag: "3.28"
             lower_bounds: true
           - python: "3.8"

--- a/CHANGES/+python38.removal
+++ b/CHANGES/+python38.removal
@@ -1,0 +1,1 @@
+Dropped support for python 3.6 and 3.7.

--- a/CHANGES/pulp-glue/+python38.removal
+++ b/CHANGES/pulp-glue/+python38.removal
@@ -1,0 +1,1 @@
+Dropped support for python 3.6 and 3.7.

--- a/lower_bounds_constraints.lock
+++ b/lower_bounds_constraints.lock
@@ -1,7 +1,8 @@
 click==8.0.0
 packaging==20.0
 PyYAML==5.3
-requests==2.24.0
+requests==2.24.0;python_version<"3.12"
+requests==2.25.1;python_version>="3.12"
 schema==0.7.5
 toml==0.10.2
 pygments==2.17.2

--- a/pulp-glue/pyproject.toml
+++ b/pulp-glue/pyproject.toml
@@ -7,7 +7,7 @@ name = "pulp-glue"
 version = "0.24.0.dev"
 description = "Version agnostic glue library to talk to pulpcore's REST API."
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 license = {text = "GPLv2+"}
 authors = [
   {name = "Pulp Team", email = "pulp-list@redhat.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pulp-cli"
 version = "0.24.0.dev"
 description = "Command line interface to talk to pulpcore's REST API."
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 license = {text = "GPLv2+"}
 authors = [
   {name = "Pulp Team", email = "pulp-list@redhat.com"},
@@ -71,9 +71,9 @@ test_matrix = """
   pulp_api_root: "/relocated/djnd/"
 - python: "3.11"
   image_tag: "latest"
-- python: "3.6"
+- python: "3.12"
   image_tag: "3.39"
-- python: "3.7"
+- python: "3.12"
   image_tag: "3.28"
   lower_bounds: true
 - python: "3.8"


### PR DESCRIPTION
Both of these versions dropped out of security maintenance for quite some while now.

[noissue]

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
