### PR TITLE
Fix username=None handling

### DIFF
--- a/CHANGES/+better_handle_auth.bugfix
+++ b/CHANGES/+better_handle_auth.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue where passing `usename=None` in `api_kwargs` was handled different than not providing it at all.

--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -307,14 +307,13 @@ class PulpContext:
         All calls to the API should be performed via `call`.
         """
         if self._api is None:
-            if self._api_kwargs.get("username"):
+            username = self._api_kwargs.pop("username", None)
+            password = self._api_kwargs.pop("password", None)
+            if username:
                 # Deprecated for 'auth'.
-                if not self._api_kwargs.get("password"):
-                    self._api_kwargs["password"] = self.prompt("password", hide_input=True)
-                self._api_kwargs["auth_provider"] = BasicAuthProvider(
-                    self._api_kwargs.pop("username"),
-                    self._api_kwargs.pop("password", None),
-                )
+                if not password:
+                    password = self.prompt("password", hide_input=True)
+                self._api_kwargs["auth_provider"] = BasicAuthProvider(username, password)
                 warnings.warn(
                     "Using 'username' and 'password' with 'PulpContext' is deprecated. "
                     "Use an auth provider with the 'auth_provider' argument instead.",


### PR DESCRIPTION
Passing username=None to api_kwargs now behaves as if it was not provided at all.

[noissue]

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
