### PR TITLE
Fix changelog parser

### DIFF
--- a/.ci/scripts/collect_changes.py
+++ b/.ci/scripts/collect_changes.py
@@ -21,8 +21,12 @@ START_STRING = tc_settings.get(
 TITLE_FORMAT = tc_settings.get("title_format", "{name} {version} ({project_date})")
 
 
+# Build a regex to find the header of a changelog section.
+# It must have a single capture group to single out the version.
+# see help(re.split) for more info.
 NAME_REGEX = r".*"
-VERSION_REGEX = r"([0-9]+\.[0-9]+\.[0-9][0-9ab]*)"
+VERSION_REGEX = r"[0-9]+\.[0-9]+\.[0-9][0-9ab]*"
+VERSION_CAPTURE_REGEX = rf"({VERSION_REGEX})"
 DATE_REGEX = r"[0-9]{4}-[0-9]{2}-[0-9]{2}"
 TITLE_REGEX = (
     "("
@@ -30,6 +34,7 @@ TITLE_REGEX = (
         TITLE_FORMAT.format(name="NAME_REGEX", version="VERSION_REGEX", project_date="DATE_REGEX")
     )
     .replace("NAME_REGEX", NAME_REGEX)
+    .replace("VERSION_REGEX", VERSION_CAPTURE_REGEX, 1)
     .replace("VERSION_REGEX", VERSION_REGEX)
     .replace("DATE_REGEX", DATE_REGEX)
     + ")"


### PR DESCRIPTION
The original version was not coping well when the version happened to appear twice in the title of a changelog.

[noissue]

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
