### PR TITLE
Add support of contains/startswith to RPM content

### DIFF
--- a/CHANGES/687.feature
+++ b/CHANGES/687.feature
@@ -1,0 +1,7 @@
+Added the below filters to `pulp rpm content list`:
+- --arch-contains
+- --arch-startswith
+- --name-contains
+- --name-startswith
+- --release-contains
+- --release-startswith

--- a/pulp-glue/pulp_glue/rpm/context.py
+++ b/pulp-glue/pulp_glue/rpm/context.py
@@ -94,6 +94,18 @@ class PulpRpmPackageContext(PulpContentContext):
                 self.pulp_ctx.needs_plugin(PluginRequirement("rpm", specifier=">=3.18.0"))
             else:
                 PulpException(_("--relative-path must be provided"))
+        contains_startswith = [
+            "name__contains",
+            "name__startswith",
+            "release__contains",
+            "release__startswith",
+            "arch__contains",
+            "arch__startswith",
+        ]
+        if any(k in body for k in contains_startswith):
+            self.pulp_ctx.needs_plugin(
+                PluginRequirement("rpm", specifier=">=3.20.0", feature=_("substring filters"))
+            )
         return body
 
 

--- a/pulpcore/cli/rpm/content.py
+++ b/pulpcore/cli/rpm/content.py
@@ -109,9 +109,19 @@ list_options = [
     pulp_option("--repository-version"),
     pulp_option("--arch", allowed_with_contexts=(PulpRpmPackageContext,)),
     pulp_option(
+        "--arch-contains",
+        "arch__contains",
+        allowed_with_contexts=(PulpRpmPackageContext,),
+    ),
+    pulp_option(
         "--arch-in", "arch__in", multiple=True, allowed_with_contexts=(PulpRpmPackageContext,)
     ),
     pulp_option("--arch-ne", "arch__ne", allowed_with_contexts=(PulpRpmPackageContext,)),
+    pulp_option(
+        "--arch-startswith",
+        "arch__startswith",
+        allowed_with_contexts=(PulpRpmPackageContext,),
+    ),
     pulp_option("--epoch", allowed_with_contexts=(PulpRpmPackageContext,)),
     pulp_option(
         "--epoch-in", "epoch__in", multiple=True, allowed_with_contexts=(PulpRpmPackageContext,)
@@ -130,6 +140,11 @@ list_options = [
     ),
     pulp_option("--name", allowed_with_contexts=(PulpRpmPackageContext, PulpRpmModulemdContext)),
     pulp_option(
+        "--name-contains",
+        "name__contains",
+        allowed_with_contexts=(PulpRpmPackageContext, PulpRpmModulemdContext),
+    ),
+    pulp_option(
         "--name-in",
         "name__in",
         multiple=True,
@@ -138,6 +153,11 @@ list_options = [
     pulp_option(
         "--name-ne",
         "name__ne",
+        allowed_with_contexts=(PulpRpmPackageContext, PulpRpmModulemdContext),
+    ),
+    pulp_option(
+        "--name-startswith",
+        "name__startswith",
         allowed_with_contexts=(PulpRpmPackageContext, PulpRpmModulemdContext),
     ),
     pulp_option("--package-href", allowed_with_contexts=(PulpRpmPackageContext,)),
@@ -150,9 +170,19 @@ list_options = [
     ),
     pulp_option("--release", allowed_with_contexts=(PulpRpmPackageContext,)),
     pulp_option(
+        "--release-contains",
+        "release__contains",
+        allowed_with_contexts=(PulpRpmPackageContext,),
+    ),
+    pulp_option(
         "--release-in", "release__in", multiple=True, allowed_with_contexts=(PulpRpmPackageContext,)
     ),
     pulp_option("--release-ne", "release__ne", allowed_with_contexts=(PulpRpmPackageContext,)),
+    pulp_option(
+        "--release-startswith",
+        "release__startswith",
+        allowed_with_contexts=(PulpRpmPackageContext,),
+    ),
     pulp_option("--severity", allowed_with_contexts=(PulpRpmAdvisoryContext,)),
     pulp_option(
         "--severity-in",

--- a/tests/scripts/pulp_rpm/test_content.sh
+++ b/tests/scripts/pulp_rpm/test_content.sh
@@ -125,6 +125,8 @@ do
   fi
 done
 
+expect_succ pulp rpm content list --name-contains "${RPM_NAME}"
+expect_succ pulp rpm content list --name-startswith "${RPM_NAME}"
 expect_succ pulp rpm content list --name-in "${RPM_NAME}" --name-in "${RPM2_NAME}"
 pulp rpm content list
 expect_succ test "$(echo "${OUTPUT}" | jq -r 'length')" -eq 2


### PR DESCRIPTION
Review Checklist:
- [x] An issue is properly linked. [feature and bugfix only]
- [x] Tests are present or not feasible.
- [x] Commits are split in a logical way (not historically).

closes #687 