### PR TITLE
Pin schema due to breakage in 0.7.6.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "pulp-glue==0.25.0.dev",
   "click>=8.0.0,<9.0.0",
   "PyYAML>=5.3,<6.1",
-  "schema>=0.7.5,<0.8",
+  "schema==0.7.5",
   "toml>=0.10.2,<0.11",
   "importlib_metadata>=4.8.0,<7.1;python_version<'3.10'",
 ]


### PR DESCRIPTION
Example:
```
~ $ pip install schema
...
Successfully installed contextlib2-21.6.0 schema-0.7.6 ~ $ python3
>>> import schema as s
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ModuleNotFoundError: No module named 'schema'
>>>
```

[noissue]

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
