### PR TITLE
Add docs migration warning and redirects from old pages

### DIFF
--- a/CHANGES/932.misc
+++ b/CHANGES/932.misc
@@ -1,0 +1,1 @@
+Added warning about the new docs location on the legacy docs and included some redirects.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+# Pulp 3 CLI Docs
+
+The documentation for pulp-cli and pulp-glue has moved to a new place.
+Go to the new site:
+
+- [pulp-cli section](https://staging-docs.pulpproject.org/pulp-cli/docs/user/)
+- [pulp-glue section](https://staging-docs.pulpproject.org/pulp-glue/docs/dev/learn/architecture/)
+
+Learn more about the new documentation project [here](https://discourse.pulpproject.org/t/unified-documentation-part-2/1188/2)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,39 +17,20 @@ markdown_extensions:
   - "pymdownx.tabbed":
       alternate_style: false
 plugins:
-  - "search"
-  - mkdocstrings:
-      default_handler: "python"
-      handlers:
-        python:
-          paths:
-            - "pulp-glue/pulp_glue"
-            - "pulp-glue"
-          options:
-            heading_level: 2
-            show_root_heading: false
-            show_root_toc_entry: false
-            show_symbol_type_heading: true
-            show_if_no_docstring: false
-            show_signature_annotations: true
-            separate_signature: true
-            members_order: "source"
-            merge_init_into_class: true
+  - redirects:
+      redirect_maps:
+        "installation.md": "index.md"
+        "configuration.md": "index.md"
+        "using_the_cli.md": "index.md"
+        "supported_workflows.md": "index.md"
+        "advanced_features.md": "index.md"
+        "CHANGES.md": "index.md"
+        "contributing.md": "index.md"
+        "architecture.md": "index.md"
+        "glue_reference/common_openapi.md": "index.md"
+        "glue_reference/common_context.md": "index.md"
+        "glue_reference/common_i18n.md": "index.md"
+        "glue_reference/core_context.md": "index.md"
+        "cli_reference/common_generic.md": "index.md"
 nav:
   - "Overview": "index.md"
-  - "installation.md"
-  - "configuration.md"
-  - "using_the_cli.md"
-  - "supported_workflows.md"
-  - "advanced_features.md"
-  - "CHANGES.md"
-  - "Developer material":
-    - "contributing.md"
-    - "architecture.md"
-  - "Pulp Glue API Reference":
-    - "glue_reference/common_openapi.md"
-    - "glue_reference/common_context.md"
-    - "glue_reference/common_i18n.md"
-    - "glue_reference/core_context.md"
-  - "Pulp CLI plumbings API Reference":
-    - "cli_reference/common_generic.md"


### PR DESCRIPTION
See https://github.com/pulp/pulp-docs/issues/33

This adds a single page to the old documentation site with a note to the docs migration. Other pages are redirected to this, so people can understand what is going on before going to the new site.

The idea is that this gets published and stays freezed until July, when we should "deactivate" all legacy docs and add broad-redirects to the production site (under pulpproject.org)

Closes #932 

Review Checklist:
- [x] An issue is properly linked. [feature and bugfix only]
- [x] Tests are present or not feasible.
- [x] Commits are split in a logical way (not historically).
