### PR TITLE
Fix the fallback logic for tls verification

### DIFF
--- a/CHANGES/pulp-glue/+ca_defaults.bugfix
+++ b/CHANGES/pulp-glue/+ca_defaults.bugfix
@@ -1,0 +1,1 @@
+Fixed the logic to use requests defaults for tls verification.

--- a/pulp-glue/pulp_glue/common/openapi.py
+++ b/pulp-glue/pulp_glue/common/openapi.py
@@ -152,8 +152,8 @@ class OpenAPI:
             self._session.headers.update(headers)
         self._session.max_redirects = 0
 
-        verify: t.Optional[t.Union[bool, str]] = (
-            os.environ.get("PULP_CA_BUNDLE") if validate_certs is not False else False
+        verify: t.Optional[t.Union[bool, str]] = validate_certs and os.environ.get(
+            "PULP_CA_BUNDLE", True
         )
         session_settings = self._session.merge_environment_settings(
             base_url, {}, None, verify, None


### PR DESCRIPTION
If no PULP_CA_BUNDLE is provided, but validte_certs is set, we should pass True to requests session.verify.