### PR TITLE
Only set auth_provider if no cert was provided

### DIFF
--- a/CHANGES/+cli_cert_auth.bugfix
+++ b/CHANGES/+cli_cert_auth.bugfix
@@ -1,0 +1,1 @@
+Fixed "Cannot use both 'auth' and 'cert'" error when trying to use pulp-cli with cert auth.

--- a/pulp-glue/pulp_glue/common/openapi.py
+++ b/pulp-glue/pulp_glue/common/openapi.py
@@ -127,12 +127,12 @@ class OpenAPI:
         self.base_url: str = base_url
         self.doc_path: str = doc_path
         self.safe_calls_only: bool = safe_calls_only
+        self.auth_provider = auth_provider
 
         self._session: requests.Session = requests.session()
-        if auth_provider:
+        if self.auth_provider:
             if cert or key:
                 raise OpenAPIError(_("Cannot use both 'auth' and 'cert'."))
-            self.auth_provider = auth_provider
         else:
             if cert and key:
                 self._session.cert = (cert, key)

--- a/pulpcore/cli/common/generic.py
+++ b/pulpcore/cli/common/generic.py
@@ -133,7 +133,8 @@ class PulpCLIContext(PulpContext):
     ) -> None:
         self.username = api_kwargs.pop("username", None)
         self.password = api_kwargs.pop("password", None)
-        api_kwargs["auth_provider"] = PulpCLIAuthProvider(pulp_ctx=self)
+        if not api_kwargs.get("cert"):
+            api_kwargs["auth_provider"] = PulpCLIAuthProvider(pulp_ctx=self)
         super().__init__(
             api_root=api_root,
             api_kwargs=api_kwargs,


### PR DESCRIPTION
Otherwise (e.g. when using cert auth), pulp_glue will error out with:

    Error: Cannot use both 'auth' and 'cert'.

Fixes: 954a7bd4899e56d641949f6a5f0fd2f257c26ae0

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
