### PR TITLE
Bump the requests version

### DIFF
--- a/pulp-glue/pyproject.toml
+++ b/pulp-glue/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "packaging>=20.0,<24",
-  "requests>=2.24.0,<2.32",
+  "requests>=2.24.0,<2.33",
   "importlib_resources>=5.4.0,<6.2;python_version<'3.9'",
 ]
 


### PR DESCRIPTION
This allows pulpcore to install a non-vulnerable version of the requests library.

https://github.com/psf/requests/security/advisories/GHSA-9wx4-h78v-vm56

[noissue]