### PR TITLE
Revert "Bump the requests version"

### DIFF
--- a/CHANGES/985.bugfix
+++ b/CHANGES/985.bugfix
@@ -1,0 +1,1 @@
+Don't allow requests-2.32 due to https instability issues with that release.

--- a/pulp-glue/pyproject.toml
+++ b/pulp-glue/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "packaging>=20.0,<24",
-  "requests>=2.24.0,<2.33",
+  "requests>=2.24.0,<2.32",
   "importlib_resources>=5.4.0,<6.2;python_version<'3.9'",
 ]
 


### PR DESCRIPTION
requests-2.32 isn't stable enough for our use yet.

This reverts commit cc1f17ff29debef71bbba8c8e94ec7e66e5067c8.

fixes #985
