### PR TITLE
Added --directory to `rpm content -t package upload`.

### DIFF
--- a/CHANGES/994.feature
+++ b/CHANGES/994.feature
@@ -1,0 +1,5 @@
+Added --directory to `rpm content -t package upload`.
+
+This finds all *.rpm in the specified directory and arranges for
+them to be added to the specified --repository as a single
+repository-version.


### PR DESCRIPTION
This finds all *.rpm in the specified directory and arranges for them to be added to the specified --repository as a single repository-version.

closes #994.

Review Checklist:
- [x] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [x] Commits are split in a logical way (not historically).
