### PR TITLE
Added --directory to `rpm content -t package upload`.

### DIFF
--- a/CHANGES/994.feature
+++ b/CHANGES/994.feature
@@ -1,0 +1,6 @@
+Expanded on options available to `rpm content -t package upload`.
+
+The user can now:
+  * Upload an entire directory of RPMs.
+  * Choose to have them added to their desired destination as a single new repository-version.
+  * Choose to have a new Publication created at the end of the uploads.

--- a/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
+++ b/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
@@ -149,5 +149,10 @@ expect_succ pulp rpm distribution create --name "cli_test_rpm_distro" \
   --repository "cli_test_rpm_repository"
 
 expect_succ pulp rpm repository sync --repository "cli_test_rpm_repository"
-expect_succ pulp rpm publication list
+if pulp debug has-plugin --name "rpm" --specifier ">=3.20.0"
+then
+  expect_succ pulp rpm publication list --repository rpm:rpm:cli_test_rpm_repository
+else
+  expect_succ pulp rpm publication list
+fi
 test "$(echo "$OUTPUT" | jq -r length)" -eq "1"


### PR DESCRIPTION
This finds all *.rpm in the specified directory and arranges for them to be added to the specified --repository, and then publishes the final resulting repository-version.

closes #994.

