### PR TITLE
Fix prompting for multivalue options on config

### DIFF
--- a/CHANGES/1008.bugfix
+++ b/CHANGES/1008.bugfix
@@ -1,0 +1,1 @@
+Fixed the interactive config generation in the face of options allowing multiple values.

--- a/pulp_cli/config.py
+++ b/pulp_cli/config.py
@@ -220,11 +220,17 @@ def create(
     def prompt_config_option(name: str) -> t.Any:
         """Find the option from the root command and prompt."""
         option = next(p for p in ctx.command.params if p.name == name)
-        if isinstance(option, click.Option) and option.help:
-            help = option.help
+        if option.multiple:
+            assert option.type == click.types.STRING
+            assert option.default is None
+            result = []
+            value = click.prompt(f"{name} (end with an empty line)", default="", type=option.type)
+            while value:
+                result.append(value)
+                value = click.prompt(f"{name} (continued)", default="", type=option.type)
+            return result
         else:
-            help = name
-        return click.prompt(help, default=(option.default), type=option.type)
+            return click.prompt(name, default=option.default, type=option.type)
 
     settings: t.MutableMapping[str, t.Any] = kwargs
     if not settings["plugins"]:


### PR DESCRIPTION
Interactive config generation did not allow to specify no headers.

fixes #1008

Review Checklist:
- [ ] An issue is properly linked. [feature and bugfix only]
- [ ] Tests are present or not feasible.
- [ ] Commits are split in a logical way (not historically).
