### PR TITLE
Fix return value of create

### DIFF
--- a/CHANGES/pulp-glue/+created_resources.bugfix
+++ b/CHANGES/pulp-glue/+created_resources.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug where `create` always returned the first entry of created resources.
+Where possible, it now compares the results with `HREF_PATTERN` to select the resource to return.


### PR DESCRIPTION
When creating entities via tasks, we need to select one from the created_resources. This will use the HREF_PATTERN to find the right one.