### PR TITLE
Add defaults to converge

### DIFF
--- a/.ci/run_container.sh
+++ b/.ci/run_container.sh
@@ -76,6 +76,7 @@ export PULP_CONTENT_ORIGIN
   --detach \
   --name "pulp-ephemeral" \
   --volume "${TMPDIR}/settings:/etc/pulp${SELINUX:+:Z}" \
+  --network bridge \
   --publish "8080:${PORT}" \
   "ghcr.io/pulp/pulp:${IMAGE_TAG}"
 

--- a/CHANGES/pulp-glue/+converge_defaults.bugfix
+++ b/CHANGES/pulp-glue/+converge_defaults.bugfix
@@ -1,0 +1,1 @@
+Added missing `defaults` argument to `converge`.

--- a/CHANGES/pulp-glue/+repository_context.feature
+++ b/CHANGES/pulp-glue/+repository_context.feature
@@ -1,0 +1,1 @@
+Added a repository scope to `PulpContentContext` to allow to operate on "content in a repository" in a natural way.

--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -1101,7 +1101,9 @@ class PulpEntityContext(PulpViewSetContext):
         )
 
     def converge(
-        self, desired_attributes: t.Optional[t.Dict[str, t.Any]]
+        self,
+        desired_attributes: t.Optional[t.Dict[str, t.Any]],
+        defaults: t.Optional[t.Dict[str, t.Any]] = None,
     ) -> t.Tuple[bool, t.Optional[EntityDefinition], t.Optional[EntityDefinition]]:
         """
         Converge an entity to have a set of desired attributes.
@@ -1110,7 +1112,10 @@ class PulpEntityContext(PulpViewSetContext):
         delete or update the entity.
 
         Parameters:
-            desired_attributes: Dictionary of attributes the entity should have.
+            desired_attributes: Dictionary of attributes the entity should have. `None` if the
+                entity is supposed to be absent.
+            defaults: Optional dict with default and extra values to be used when creating a new
+                entity.
 
         Returns:
             Tuple of (changed, before, after)
@@ -1126,12 +1131,11 @@ class PulpEntityContext(PulpViewSetContext):
                 return True, entity, None
         else:
             if entity is None:
-                # --- Not in Python 3.8 ---
-                # desired_entity = self._entity_lookup | desired_attributes
                 desired_entity: t.Dict[str, t.Any] = {}
-                desired_entity.update(self._entity_lookup)
+                if defaults:
+                    desired_entity.update(defaults)
                 desired_entity.update(desired_attributes)
-                # -------------------------
+                desired_entity.update(self._entity_lookup)
                 desired_entity.pop("pulp_href", None)
                 return True, None, self.create(desired_entity)
             else:


### PR DESCRIPTION
This helps to use converge in more complex situations, where some default values and extra data is only needed when creating the entity but is in the way when updating it.