### PR TITLE
Fix error in safe_calls_only without fake_mode

### DIFF
--- a/CHANGES/pulp-glue/1037.bugfix
+++ b/CHANGES/pulp-glue/1037.bugfix
@@ -1,0 +1,1 @@
+Fixed an error where safemode wrongly complained to be in `fake_mode`.

--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -378,8 +378,11 @@ class PulpContext:
                 body=body,
                 validate_body=validate_body,
             )
-        except UnsafeCallError:
-            raise NotImplementedFake(f"Operation {operation_id} was attempted in fake mode.")
+        except UnsafeCallError as e:
+            if self.fake_mode:
+                raise NotImplementedFake(f"Operation {operation_id} was attempted in fake mode.")
+            else:
+                raise PulpException(str(e))
         except OpenAPIError as e:
             raise PulpException(str(e))
         except HTTPError as e:

--- a/pulp-glue/pulp_glue/core/context.py
+++ b/pulp-glue/pulp_glue/core/context.py
@@ -288,7 +288,11 @@ class PulpOrphanContext(PulpViewSetContext):
         else:
             if body:
                 self.pulp_ctx.needs_plugin(PluginRequirement("core", specifier=">=3.14.0"))
-            result = self.pulp_ctx.call("orphans_delete")
+            if not self.pulp_ctx.fake_mode:
+                result = self.pulp_ctx.call("orphans_delete")
+            else:
+                # Do we need something better?
+                result = {}
         return result
 
 


### PR DESCRIPTION
When fake mode was not explicitely selected complaining about unsafe calls in fake_mode is not nice. Instead, we fall back to the original error message in that case.