### PR TITLE
Fix stray click import in pulp-glue

### DIFF
--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -240,9 +240,8 @@ class PulpContext:
         Abstract function that will be called to emit warnings and task progress.
 
         Warning:
-            This function needs to be implemented.
+            This function does nothing until implemented by a subclass.
         """
-        raise NotImplementedError("PulpContext is an abstract class.")
 
     def prompt(self, text: str, hide_input: bool = False) -> str:
         """
@@ -250,6 +249,7 @@ class PulpContext:
 
         Note:
             If a password is provided non-interactively, this function need not be implemented.
+            Doing so is deprecated.
         """
         raise NotImplementedError("PulpContext is an abstract class.")
 

--- a/pulp-glue/pulp_glue/rpm/context.py
+++ b/pulp-glue/pulp_glue/rpm/context.py
@@ -1,7 +1,5 @@
 import typing as t
 
-import click
-
 from pulp_glue.common.context import (
     EntityDefinition,
     PluginRequirement,
@@ -70,7 +68,7 @@ class PulpRpmCompsXmlContext(PulpEntityContext):
     def upload_comps(
         self, file: t.IO[bytes], repo_href: t.Optional[str], replace: t.Optional[bool]
     ) -> t.Any:
-        click.echo(_("Uploading file {filename}").format(filename=file.name), err=True)
+        self.pulp_ctx.echo(_("Uploading file {filename}").format(filename=file.name), err=True)
         file.seek(0)
         return self.call(
             "upload_comps",


### PR DESCRIPTION
Pulp GLUE deliberately does not depend on click. For echoing status messages, PulpContext.echo should be used.