### PR TITLE
Add from_config to PulpContext

### DIFF
--- a/CHANGES/pulp-glue/1060.feature
+++ b/CHANGES/pulp-glue/1060.feature
@@ -1,0 +1,1 @@
+Added `from_config` constructor to `PulpContext` class.


### PR DESCRIPTION
This will merge files from the usual config locations or a separate given set and merge them to generate a useable PulpContext object for the specified profile.

fixes #1060