### PR TITLE
Fixed the logic of the warning in list

### DIFF
--- a/CHANGES/pulp-glue/1068.bugfix
+++ b/CHANGES/pulp-glue/1068.bugfix
@@ -1,0 +1,1 @@
+Fixed the "list" commands to show the notification about not displaying all items when it shouldn't and the other way around.

--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -845,6 +845,8 @@ class PulpEntityContext(PulpViewSetContext):
                     self.list_iterator(parameters=parameters, offset=offset, stats=stats)
                 )
         except StopIteration:
+            pass
+        else:
             self.pulp_ctx.echo(
                 _("Not all {count} entries were shown.").format(count=stats["count"]), err=True
             )


### PR DESCRIPTION
The warning about not all items have been shown in the list call was exactly the wrong way around.
It we actually hit StopIteration, we _have_ seen them all.

fixes #1068