### PR TITLE
Fix from_config messing up headers

### DIFF
--- a/CHANGES/+from_config.bugfix
+++ b/CHANGES/+from_config.bugfix
@@ -1,0 +1,1 @@
+Fixes `from_config` call that messed up the headers attribute.

--- a/pulp-glue/pulp_glue/common/context.py
+++ b/pulp-glue/pulp_glue/common/context.py
@@ -344,8 +344,8 @@ class PulpContext:
         if "username" in config:
             api_kwargs["auth_provider"] = BasicAuthProvider(config["username"], config["password"])
         if "headers" in config:
-            api_kwargs["headers"] = (
-                dict((header.split(":", maxsplit=1) for header in config["headers"])),
+            api_kwargs["headers"] = dict(
+                (header.split(":", maxsplit=1) for header in config["headers"])
             )
         for key in ["cert", "key", "user_agent", "cid"]:
             if key in config:

--- a/pulp-glue/tests/conftest.py
+++ b/pulp-glue/tests/conftest.py
@@ -17,23 +17,9 @@ def pulp_ctx(
     request: pytest.FixtureRequest, pulp_cli_settings: t.Dict[str, t.Dict[str, t.Any]]
 ) -> PulpContext:
     verbose = request.config.getoption("verbose")
-    settings = pulp_cli_settings["cli"]
-    return PulpTestContext(
-        api_kwargs={
-            "base_url": settings["base_url"],
-            "auth_provider": (
-                BasicAuthProvider(settings.get("username"), settings.get("password"))
-                if "username" in settings
-                else None
-            ),
-            "cert": settings.get("cert"),
-            "key": settings.get("key"),
-            "debug_callback": lambda i, s: i <= verbose and print(s),
-        },
-        api_root=settings.get("api_root", "pulp/"),
-        background_tasks=False,
-        timeout=settings.get("timeout", 120),
-    )
+    settings = pulp_cli_settings["cli"].copy()
+    settings["debug_callback"] = lambda i, s: i <= verbose and print(s)
+    return PulpTestContext.from_config(settings)
 
 
 @pytest.fixture


### PR DESCRIPTION
An extra comma creating a tuple made the function unusable.