### PR TITLE
Update base_url in test if content_origin is null

### DIFF
--- a/tests/scripts/pulp_file/test_distribution.sh
+++ b/tests/scripts/pulp_file/test_distribution.sh
@@ -59,6 +59,13 @@ fi
 expect_succ pulp file distribution list --base-path "cli_test_file_distro"
 test "$(echo "$OUTPUT" | jq -r length)" -eq 1
 base_url="$(echo "$OUTPUT" | jq -r .[0].base_url)"
+
+# if base_url starts with "/" (relative path) we need to prepend it with the server address
+if [[ $base_url == /* ]]
+then
+  base_url="http://localhost:8080${base_url}"
+fi
+
 expect_succ pulp file distribution list --base-path-contains "CLI"
 test "$(echo "$OUTPUT" | jq -r length)" -gt 0
 


### PR DESCRIPTION
If `content_origin` is not set, the `distribution.base_url` will be defined with the relative path and the curl command in the test script will fail to run because of the missing hostname/address.

ref: https://github.com/pulp/pulpcore/pull/6175