### PR TITLE
Remove aspects of tests not testing the cli

### DIFF
--- a/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
+++ b/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
@@ -16,18 +16,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-if [ "$VERIFY_SSL" = "false" ]
-then
-  curl_opt=("-k")
-else
-  if [ "${PULP_CA_BUNDLE:+x}" ]
-  then
-    curl_opt=("--cacert" "${PULP_CA_BUNDLE}")
-  else
-    curl_opt=()
-  fi
-fi
-
 # Add content using JSON file
 cat <<EOT >> repo_config.json
 {
@@ -84,14 +72,6 @@ fi
 expect_succ pulp rpm distribution create --name "cli_test_rpm_distro" \
   --base-path "cli_test_rpm_distro" \
   --publication "$PUBLICATION_HREF"
-DISTRIBUTION_BASE_URL=$(echo "$OUTPUT" | jq -r .base_url)
-
-if pulp debug has-plugin --name "rpm" --specifier "<3.23.0"
-then
-  expect_succ curl "${curl_opt[@]}" --head --fail "${DISTRIBUTION_BASE_URL}config.repo"
-else
-  expect_fail curl "${curl_opt[@]}" --head --fail "${DISTRIBUTION_BASE_URL}config.repo"
-fi
 
 if pulp debug has-plugin --name "rpm" --specifier ">=3.23.0"
 then
@@ -99,8 +79,6 @@ then
     --base-path "cli_test_rpm_distro2" \
     --publication "$PUBLICATION_HREF" \
     --generate-repo-config
-  DISTRIBUTION_BASE_URL=$(echo "$OUTPUT" | jq -r .base_url)
-  expect_succ curl "${curl_opt[@]}" --head --fail "${DISTRIBUTION_BASE_URL}config.repo"
   expect_succ pulp rpm distribution destroy --name "cli_test_rpm_distro2"
 fi
 


### PR DESCRIPTION
Apparently we can no longer assume that base_url is an url. But also this really is not testing CLI behaviour and should not be here in the first place.