### PR TITLE
Add support for checkpoint distributions and publications

### DIFF
--- a/CHANGES/1129.feature
+++ b/CHANGES/1129.feature
@@ -1,0 +1,1 @@
+Added support for checkpoint distributions and publications.

--- a/pulpcore/cli/file/distribution.py
+++ b/pulpcore/cli/file/distribution.py
@@ -1,6 +1,10 @@
 import click
+from pulp_glue.common.context import PluginRequirement
 from pulp_glue.common.i18n import get_translation
-from pulp_glue.file.context import PulpFileDistributionContext, PulpFileRepositoryContext
+from pulp_glue.file.context import (
+    PulpFileDistributionContext,
+    PulpFileRepositoryContext,
+)
 
 from pulpcore.cli.common.generic import (
     PulpCLIContext,
@@ -17,6 +21,7 @@ from pulpcore.cli.common.generic import (
     pass_pulp_context,
     pulp_group,
     pulp_labels_option,
+    pulp_option,
     resource_option,
     role_command,
     show_command,
@@ -71,6 +76,13 @@ update_options = [
     repository_option,
     content_guard_option,
     pulp_labels_option,
+    pulp_option(
+        "--checkpoint/--not-checkpoint",
+        is_flag=True,
+        default=None,
+        help=_("Create a checkpoint distribution."),
+        needs_plugins=[PluginRequirement("core", specifier=">=3.74.0")],
+    ),
 ]
 create_options = common_distribution_create_options + update_options
 

--- a/pulpcore/cli/file/publication.py
+++ b/pulpcore/cli/file/publication.py
@@ -1,6 +1,10 @@
 import click
+from pulp_glue.common.context import PluginRequirement
 from pulp_glue.common.i18n import get_translation
-from pulp_glue.file.context import PulpFilePublicationContext, PulpFileRepositoryContext
+from pulp_glue.file.context import (
+    PulpFilePublicationContext,
+    PulpFileRepositoryContext,
+)
 
 from pulpcore.cli.common.generic import (
     PulpCLIContext,
@@ -11,6 +15,7 @@ from pulpcore.cli.common.generic import (
     pass_pulp_context,
     publication_filter_options,
     pulp_group,
+    pulp_option,
     resource_option,
     role_command,
     show_command,
@@ -55,6 +60,13 @@ create_options = [
     click.option(
         "--manifest",
         help=_("Filename to use for manifest file containing metadata for all the files."),
+    ),
+    pulp_option(
+        "--checkpoint",
+        is_flag=True,
+        default=None,
+        help=_("Create a checkpoint publication"),
+        needs_plugins=[PluginRequirement("core", specifier=">=3.74.0")],
     ),
 ]
 publication.add_command(list_command(decorators=publication_filter_options + [repository_option]))

--- a/pulpcore/cli/rpm/distribution.py
+++ b/pulpcore/cli/rpm/distribution.py
@@ -1,4 +1,5 @@
 import click
+from pulp_glue.common.context import PluginRequirement
 from pulp_glue.common.i18n import get_translation
 from pulp_glue.rpm.context import PulpRpmDistributionContext, PulpRpmRepositoryContext
 
@@ -76,6 +77,12 @@ update_options = [
     repository_option,
     content_guard_option,
     pulp_labels_option,
+    pulp_option(
+        "--checkpoint/--not-checkpoint",
+        is_flag=True,
+        default=None,
+        needs_plugins=[PluginRequirement("rpm", specifier=">=3.29.0")],
+    ),
 ]
 create_options = common_distribution_create_options + update_options
 

--- a/pulpcore/cli/rpm/publication.py
+++ b/pulpcore/cli/rpm/publication.py
@@ -74,6 +74,13 @@ create_options = [
         ),
         needs_plugins=[PluginRequirement("rpm", specifier=">=3.25.0")],
     ),
+    pulp_option(
+        "--checkpoint",
+        is_flag=True,
+        default=None,
+        help=_("Create a checkpoint publication"),
+        needs_plugins=[PluginRequirement("rpm", specifier=">=3.29.0")],
+    ),
 ]
 publication.add_command(list_command(decorators=publication_filter_options + [repository_option]))
 publication.add_command(show_command(decorators=lookup_options))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,7 +207,7 @@ exclude = "cookiecutter"
 # This section is managed by the cookiecutter templates.
 profile = "black"
 line_length = 100
-skip = ["pulp-glue", "cookiecutter"]
+extend_skip = ["pulp-glue", "cookiecutter"]
 
 [tool.flake8]
 # This section is managed by the cookiecutter templates.


### PR DESCRIPTION
This is the pulp-cli change that goes along with the new checkpoint feature: https://github.com/pulp/pulpcore/pull/6245

fixes #1129