### PR TITLE
Fix headers with special characters in config

### DIFF
--- a/CHANGES/1139.bugfix
+++ b/CHANGES/1139.bugfix
@@ -1,0 +1,2 @@
+Fix a bug when header values weren't allowed to contain other than alphanumeric characters.
+Also combine the headers from setting and the commandline.

--- a/tests/scripts/test_debug_api.sh
+++ b/tests/scripts/test_debug_api.sh
@@ -5,5 +5,7 @@ set -eu
 . "$(dirname "$(realpath "$0")")"/config.source
 
 expect_succ pulp -v status
-
 echo "${ERROUTPUT}" | grep -q "^status_read : get https\?://\w.*/api/v3/status/$"
+
+expect_succ pulp -vv --header "test-header:Value with space" status
+echo "${ERROUTPUT}" | grep -q "^  test-header: Value with space$"


### PR DESCRIPTION
This adjusts the regular expression for headers to allow all characters in the value. It also adds the same validation to the header option and merges headers from config and options.