### PR TITLE
Remove support for deprecated RPM features with newer versions

### DIFF
--- a/CHANGES/+remove-old-rpm-features.removal
+++ b/CHANGES/+remove-old-rpm-features.removal
@@ -1,0 +1,1 @@
+Removed support for the old options `--package-checksum-type`, `--metadata-checksum-type`, `--gpgcheck`, and `--repo-gpgcheck` for newer version of pulp_rpm. These options have been deprecated for some time.

--- a/CHANGES/pulp-glue/+remove-old-rpm-features.removal
+++ b/CHANGES/pulp-glue/+remove-old-rpm-features.removal
@@ -1,0 +1,1 @@
+Removed support for gpgcheck, repo_gpgcheck, package_checksum_type and metadata_checksum_type for the RPM plugin for version >=3.30.0

--- a/pulp-glue/pulp_glue/rpm/context.py
+++ b/pulp-glue/pulp_glue/rpm/context.py
@@ -266,6 +266,15 @@ class PulpRpmPublicationContext(PulpPublicationContext):
             package_checksum_type = body.get("metadata_checksum_type")
             disallowed_checksums = {"md5", "sha1", "sha224"}
 
+            self.pulp_ctx.needs_plugin(
+                PluginRequirement(
+                    "rpm",
+                    specifier=">=3.30.0",
+                    inverted=True,
+                    feature=_("package_checksum_type/metadata_checksum_type"),
+                )
+            )
+
             if metadata_checksum_type and metadata_checksum_type in disallowed_checksums:
                 self.pulp_ctx.needs_plugin(
                     PluginRequirement(
@@ -278,6 +287,16 @@ class PulpRpmPublicationContext(PulpPublicationContext):
                         "rpm", specifier=">=3.25.0", inverted=True, feature=_("weak checksums")
                     )
                 )
+        if "repo_gpgcheck" in body or "gpgcheck" in body:
+            self.pulp_ctx.needs_plugin(
+                PluginRequirement(
+                    "rpm",
+                    specifier=">=3.30.0",
+                    inverted=True,
+                    feature=_("gpgcheck/repo_gpgcheck"),
+                )
+            )
+
         return body
 
 
@@ -362,6 +381,15 @@ class PulpRpmRepositoryContext(PulpRepositoryContext):
             package_checksum_type = body.get("metadata_checksum_type")
             disallowed_checksums = {"md5", "sha1", "sha224"}
 
+            self.pulp_ctx.needs_plugin(
+                PluginRequirement(
+                    "rpm",
+                    specifier=">=3.30.0",
+                    inverted=True,
+                    feature=_("package_checksum_type/metadata_checksum_type"),
+                )
+            )
+
             if metadata_checksum_type and metadata_checksum_type in disallowed_checksums:
                 self.pulp_ctx.needs_plugin(
                     PluginRequirement(
@@ -383,6 +411,17 @@ class PulpRpmRepositoryContext(PulpRepositoryContext):
                     feature=_("checksum_type"),
                 )
             )
+
+        if "repo_gpgcheck" in body or "gpgcheck" in body:
+            self.pulp_ctx.needs_plugin(
+                PluginRequirement(
+                    "rpm",
+                    specifier=">=3.30.0",
+                    inverted=True,
+                    feature=_("gpgcheck/repo_gpgcheck"),
+                )
+            )
+
         return body
 
     def sync(self, body: t.Optional[EntityDefinition] = None) -> t.Any:

--- a/pulpcore/cli/rpm/repository.py
+++ b/pulpcore/cli/rpm/repository.py
@@ -145,18 +145,23 @@ update_options = [
     click.option("--retain-package-versions", type=int),
     remote_option,
     metadata_signing_service_option,
-    click.option(
+    pulp_option(
         "--metadata-checksum-type",
         type=click.Choice(LEGACY_CHECKSUM_CHOICES, case_sensitive=False),
-        help=_("DEPRECATED: Option specifying the checksum type to use for repository metadata."),
+        help=_(
+            "DEPRECATED: Option specifying the checksum type to use for repository metadata. "
+            "Unavailable for pulp_rpm>=3.30.0"
+        ),
+        needs_plugins=[PluginRequirement("rpm", specifier="<3.30.0")],
     ),
-    click.option(
+    pulp_option(
         "--package-checksum-type",
         type=click.Choice(LEGACY_CHECKSUM_CHOICES, case_sensitive=False),
         help=_(
             "DEPRECATED: Option specifying the checksum type to use for packages in "
-            "repository metadata."
+            "repository metadata. Unavailable for pulp_rpm>=3.30.0"
         ),
+        needs_plugins=[PluginRequirement("rpm", specifier="<3.30.0")],
     ),
     pulp_option(
         "--checksum-type",
@@ -166,31 +171,34 @@ update_options = [
         ),
         needs_plugins=[PluginRequirement("rpm", specifier=">=3.25.0")],
     ),
-    click.option(
+    pulp_option(
         "--gpgcheck",
         type=click.Choice(("0", "1")),
         callback=choice_to_int_callback,
         help=_(
             """DEPRECATED: Option specifying whether a client should perform a GPG signature check
-            on packages."""
+            on packages. Unavailable for pulp_rpm>=3.30.0"""
         ),
+        needs_plugins=[PluginRequirement("rpm", specifier="<3.30.0")],
     ),
-    click.option(
+    pulp_option(
         "--repo-gpgcheck",
         type=click.Choice(("0", "1")),
         callback=choice_to_int_callback,
         help=_(
             """DEPRECATED: Option specifying whether a client should perform a GPG signature check
-            on the repodata."""
+            on the repodata. Unavailable for pulp_rpm>=3.30.0"""
         ),
+        needs_plugins=[PluginRequirement("rpm", specifier="<3.30.0")],
     ),
-    click.option(
+    pulp_option(
         "--sqlite-metadata/--no-sqlite-metadata",
         default=None,
         help=_(
             """DEPRECATED: An option specifying whether Pulp should generate SQLite metadata.
             Unavailable for pulp_rpm>=3.25.0"""
         ),
+        needs_plugins=[PluginRequirement("rpm", specifier="<3.25.0")],
     ),
     pulp_option(
         "--autopublish/--no-autopublish",

--- a/tests/scripts/pulp_rpm/gpgcheck_test.sh
+++ b/tests/scripts/pulp_rpm/gpgcheck_test.sh
@@ -10,12 +10,31 @@ cleanup () {
 }
 trap cleanup EXIT
 
-expect succ pulp rpm repository create --name "cli-repo-gpgcheck" --gpgcheck 1 --repo-gpgcheck 1
-expect succ pulp rpm repository show --name "cli-repo-gpgcheck"
-test "$(echo "$OUTPUT" | jq -r '.gpgcheck')" = 1
-test "$(echo "$OUTPUT" | jq -r '.repo_gpgcheck')" = 1
+if pulp debug has-plugin --name "rpm" --specifier "<=3.29.0"
+then
+  expect succ pulp rpm repository create --name "cli-repo-gpgcheck" --gpgcheck 1 --repo-gpgcheck 1
+  expect succ pulp rpm repository show --name "cli-repo-gpgcheck"
+  test "$(echo "$OUTPUT" | jq -r '.gpgcheck')" = 1
+  test "$(echo "$OUTPUT" | jq -r '.repo_gpgcheck')" = 1
 
-expect succ pulp rpm repository update --name "cli-repo-gpgcheck" --gpgcheck 0 --repo-gpgcheck 0
-expect succ pulp rpm repository show --name "cli-repo-gpgcheck"
-test "$(echo "$OUTPUT" | jq -r '.gpgcheck')" = 0
-test "$(echo "$OUTPUT" | jq -r '.repo_gpgcheck')" = 0
+  expect succ pulp rpm repository update --name "cli-repo-gpgcheck" --gpgcheck 0 --repo-gpgcheck 0
+  expect succ pulp rpm repository show --name "cli-repo-gpgcheck"
+  test "$(echo "$OUTPUT" | jq -r '.gpgcheck')" = 0
+  test "$(echo "$OUTPUT" | jq -r '.repo_gpgcheck')" = 0
+else
+  expect fail pulp rpm repository create --name "cli-repo-gpgcheck" --gpgcheck 1
+  expect fail pulp rpm repository create --name "cli-repo-gpgcheck" --repo-gpgcheck 1
+fi
+
+if pulp debug has-plugin --name "rpm" --specifier ">=3.24.0"
+then
+  expect succ pulp rpm repository create --name "cli-repo-config" --repo-config "{\"gpgcheck\"=1, \"repo_gpgcheck\"=1}"
+  expect succ pulp rpm repository show --name "cli-repo-config"
+  test "$(echo "$OUTPUT" | jq -r '.gpgcheck')" = 1
+  test "$(echo "$OUTPUT" | jq -r '.repo_gpgcheck')" = 1
+
+  expect succ pulp rpm repository update --name "cli-repo-config" --repo-config "{\"gpgcheck\"=0, \"repo_gpgcheck\"=0}"
+  expect succ pulp rpm repository show --name "cli-repo-config"
+  test "$(echo "$OUTPUT" | jq -r '.gpgcheck')" = 0
+  test "$(echo "$OUTPUT" | jq -r '.repo_gpgcheck')" = 0
+fi

--- a/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
+++ b/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
@@ -106,8 +106,12 @@ then
 
   expect_succ pulp rpm repository update --name "cli_test_rpm_repository" --checksum-type sha512
   expect_fail pulp rpm repository update --name "cli_test_rpm_repository" --checksum-type sha1
-  expect_fail pulp rpm repository update --name "cli_test_rpm_repository" --package-checksum-type sha1
-  expect_fail pulp rpm repository update --name "cli_test_rpm_repository" --metadata-checksum-type sha1
+
+  if pulp debug has-plugin --name "rpm" --specifier ">=3.30.0"
+  then
+    expect_fail pulp rpm repository update --name "cli_test_rpm_repository" --package-checksum-type sha256
+    expect_fail pulp rpm repository update --name "cli_test_rpm_repository" --metadata-checksum-type sha256
+  fi
 else
   expect_succ pulp rpm repository update --name "cli_test_rpm_repository" --metadata-checksum-type sha1
   expect_succ pulp rpm repository update --name "cli_test_rpm_repository" --package-checksum-type sha1


### PR DESCRIPTION
Remove gpgcheck, repo_gpgcheck, package_checksum_type and metadata_checksum_type options when working against a newer version of the RPM plugin (3.30.0+)

These have been deprecated for more than a year and the backing functionality is being removed.