### PR TITLE
Pin click to z-streams

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers=[
 ]
 dependencies = [
   "pulp-glue==0.33.0.dev",
-  "click>=8.0.0,<9",
+  "click>=8.0.0,<8.2",  # Proven to not do semver.
   "PyYAML>=5.3,<6.1",
   "schema>=0.7.5,<0.8",
   "tomli>=2.0.0,<2.1;python_version<'3.11'",


### PR DESCRIPTION
It turns out the click library introduces breaking changes with y-releases.