### PR TITLE
rpm: Skip explicit publishing after package upload if repo has autopublish enabled

### DIFF
--- a/CHANGES/1284.bugfix
+++ b/CHANGES/1284.bugfix
@@ -1,0 +1,1 @@
+Fix CLI explicitly creating a publication after package upload when repo has autopublish enabled

--- a/pulpcore/cli/rpm/content.py
+++ b/pulpcore/cli/rpm/content.py
@@ -401,7 +401,12 @@ def upload(
 
         # Sanity: ignore publish|use_temp unless destination-repository has been specified
         use_tmp = final_dest_repo_ctx and kwargs["use_temp_repository"]
-        do_publish = final_dest_repo_ctx and kwargs["publish"]
+        # Publish if autopublish is not enabled on the repository
+        do_publish = (
+            final_dest_repo_ctx
+            and kwargs["publish"]
+            and not final_dest_repo_ctx.entity["autopublish"]
+        )
 
         # Sanity: ignore relative_path if directory specified
         if directory and kwargs["relative_path"]:


### PR DESCRIPTION
closes #1284