### PR TITLE
Add repository option to python content create

### DIFF
--- a/CHANGES/+python-content-upload.removal
+++ b/CHANGES/+python-content-upload.removal
@@ -1,0 +1,1 @@
+Deprecated `pulp python content upload` command. Use `pulp python content create` instead.

--- a/pulpcore/cli/python/content.py
+++ b/pulpcore/cli/python/content.py
@@ -142,6 +142,7 @@ create_options = [
         ),
         allowed_with_contexts=(PulpPythonContentContext,),
     ),
+    repository_option,
 ]
 provenance_create_options = [
     package_option,
@@ -202,7 +203,7 @@ def upload(
     attestations: list[t.Any] | None,
     repository: PulpPythonRepositoryContext | None,
 ) -> None:
-    """Create a Python package content unit through uploading a file"""
+    """Create a Python package content unit through uploading a file [deprecated]"""
     assert isinstance(entity_ctx, PulpPythonContentContext)
 
     result = entity_ctx.upload(

--- a/tests/scripts/pulp_python/test_content.sh
+++ b/tests/scripts/pulp_python/test_content.sh
@@ -20,6 +20,7 @@ sha256=$(sha256sum "shelf-reader-0.1.tar.gz" | cut -d' ' -f1)
 
 expect_succ pulp python repository create --name "cli_test_python_upload_repository"
 expect_succ pulp python content upload --file "shelf-reader-0.1.tar.gz" --relative-path "shelf-reader-0.1.tar.gz" --repository "cli_test_python_upload_repository"
+expect_succ pulp python content create --file "shelf-reader-0.1.tar.gz" --relative-path "shelf-reader-0.1.tar.gz" --repository "cli_test_python_upload_repository"
 expect_succ pulp artifact list --sha256 "$sha256"
 expect_succ pulp python content list --filename "shelf-reader-0.1.tar.gz"
 content_href="$(echo "$OUTPUT" | tr '\r\n' ' ' | jq -r .[0].pulp_href)"


### PR DESCRIPTION
Since the create generic can now handle everything upload use to do, moving everything over and deprecating upload.