### PR TITLE
Fix pulpcore check on test profile task artifact download

### DIFF
--- a/tests/scripts/pulpcore/test_task.sh
+++ b/tests/scripts/pulpcore/test_task.sh
@@ -66,7 +66,7 @@ expect_succ pulp task list --started-before "21/01/12" --started-after "22/01/06
 expect_succ pulp task list --finished-before "2021-12-01" --finished-after "2022-06-01 00:00:00"
 expect_succ pulp task list --created-resource "$created_resource"
 
-if pulp debug has-plugin --name "core" --specifier ">=3.57.0"
+if pulp debug has-plugin --name "core" --specifier ">=3.82.0"
 then
   # Downloading profile artifacts.
   expect_succ pulp task profile-artifact-urls --uuid "${task_uuid}"


### PR DESCRIPTION
This will fix the pulpcore 3.63 and 3.73 CI updates by no longer requiring having to set the TASK_DIAGNOSTICS setting for the cli tests to pass.

Before 3.82 anytime you set TASK_DIAGNOSTICS it would always run the task with the profilers. After 3.82 it will only run the profilers if you specify the header on task creation. The update-ci jobs fail on the domain artifact creation test since the upload task ends up creating an extra profile artifact. 
