### PR TITLE
Add support for q-select parameter during replication

### DIFF
--- a/CHANGES/+replicate-q-select.feature
+++ b/CHANGES/+replicate-q-select.feature
@@ -1,0 +1,1 @@
+Added `--q-select` option to `pulp upstream-pulp replicate` for selectively syncing a subset of upstream distributions without modifying the stored upstream-pulp configuration.

--- a/CHANGES/pulp-glue/+replicate-q-select.feature
+++ b/CHANGES/pulp-glue/+replicate-q-select.feature
@@ -1,0 +1,1 @@
+Added `body` parameter to `PulpUpstreamPulpContext.replicate()` for passing per-request options like `q_select` for `core>=3.113.0`.

--- a/pulp-glue/src/pulp_glue/core/context.py
+++ b/pulp-glue/src/pulp_glue/core/context.py
@@ -628,8 +628,8 @@ class PulpUpstreamPulpContext(PulpEntityContext):
             )
         return search_result[0]
 
-    def replicate(self) -> t.Any:
-        return self.call("replicate", parameters={self.HREF: self.pulp_href})
+    def replicate(self, body: EntityDefinition | None = None) -> t.Any:
+        return self.call("replicate", parameters={self.HREF: self.pulp_href}, body=body or {})
 
 
 class PulpVulnerabilityReportContext(PulpEntityContext):

--- a/src/pulpcore/cli/core/upstream_pulp.py
+++ b/src/pulpcore/cli/core/upstream_pulp.py
@@ -86,7 +86,14 @@ upstream_pulp.add_command(destroy_command(decorators=lookup_options))
 
 @upstream_pulp.command()
 @lookup_option
+@pulp_option(
+    "--q-select",
+    needs_plugins=[PluginRequirement("core", specifier=">=3.113.0")],
+)
 @pass_entity_context
-def replicate(upstream_pulp_ctx: PulpEntityContext, /) -> None:
+def replicate(upstream_pulp_ctx: PulpEntityContext, /, q_select: str | None) -> None:
     assert isinstance(upstream_pulp_ctx, PulpUpstreamPulpContext)
-    upstream_pulp_ctx.replicate()
+    body = {}
+    if q_select is not None:
+        body["q_select"] = q_select
+    upstream_pulp_ctx.replicate(body=body)

--- a/tests/scripts/pulpcore/test_upstream_pulp.sh
+++ b/tests/scripts/pulpcore/test_upstream_pulp.sh
@@ -33,4 +33,9 @@ fi
 # Also this is a real dangerous command, deleting all existing repositories.
 expect_fail pulp upstream-pulp replicate --id "cli_test_upstream_pulp"
 
+if pulp debug has-plugin --name "core" --specifier ">=3.113.0"
+then
+  expect_fail pulp upstream-pulp replicate --id "cli_test_upstream_pulp" --q-select "pulp_label_select=doesnotexist"
+fi
+
 expect_succ pulp upstream-pulp destroy --id "cli_test_upstream_pulp"


### PR DESCRIPTION
pulpcore 3.113 adds support for replicating only a subset of the UpstreamPulp repos.