### PR TITLE
Relax pydantic version constraint

### DIFF
--- a/pulp-glue/pyproject.toml
+++ b/pulp-glue/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 dependencies = [
   "multidict>=6.0.5,<6.8",
   "packaging>=22.0,<=26.2",  # CalVer
-  "pydantic>=2.9.2,<2.13",
+  "pydantic>=2.9.2,<3",  # Stable with the exception of experimental features. https://pydantic.dev/docs/validation/latest/get-started/version-policy
   "requests>=2.24.0,<2.34",
   "tomli>=2.0.0,<2.1;python_version<'3.11'",
 ]


### PR DESCRIPTION
It declares to be stable with the exception of unstable features. We should be ok pinning to the major version.