### PR TITLE
Allow setting `retain_repo_versions` to `null`

### DIFF
--- a/CHANGES/+retain_repo_versions.bugfix
+++ b/CHANGES/+retain_repo_versions.bugfix
@@ -1,0 +1,1 @@
+Fixed empty string not being accepted as the value of `--retain-repo-versions`.

--- a/src/pulp_cli/generic.py
+++ b/src/pulp_cli/generic.py
@@ -1368,7 +1368,7 @@ retained_versions_option = pulp_option(
     "--retain-repo-versions",
     needs_plugins=[PluginRequirement("core", specifier=">=3.13.0")],
     help=_("Number of repository versions to keep."),
-    type=int,
+    type=int_or_empty,
 )
 
 pulp_labels_option = pulp_option(


### PR DESCRIPTION
Setting is already `NULLABLE` in
`pulp-glue/src/pulp_glue/common/context.py` line 1586

```
NULLABLES = {"description", "remote", "retain_repo_versions"}
```

but cli didn't allow an empty string to be used.