### PR TITLE
Allow filtering livetest runs via PYTEST_MARK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,11 @@ _test: | tests/cli.toml
 test:
 	uv run $(MAKE) _test
 
+PYTEST_MARK ?= live
+
 .PHONY: _livetest
 _livetest: | tests/cli.toml
-	pytest -v tests pulp-glue/tests -m live
+	pytest -v tests pulp-glue/tests -m "$(PYTEST_MARK)"
 
 .PHONY: livetest
 livetest:


### PR DESCRIPTION
## Summary
- Add a `PYTEST_MARK` make variable to the `livetest` target, defaulting to `live`
- Plugin CI can now run only the live tests for a single component, e.g. `make livetest PYTEST_MARK="live and pulp_container"`

## Test plan
- [ ] `make livetest` still runs the full live suite (default unchanged)
- [ ] `make livetest PYTEST_MARK="live and pulp_container"` runs only container live tests
- [ ] Update plugin CI `script.sh` to use the filtered invocation once this is released


Made with [Cursor](https://cursor.com)