### PR TITLE
Add PYTEST_MARK makefile var to cookiecutter

### DIFF
--- a/cookiecutter/ci/{{ cookiecutter.__project_name }}/Makefile
+++ b/cookiecutter/ci/{{ cookiecutter.__project_name }}/Makefile
@@ -71,9 +71,11 @@ _test: | tests/cli.toml
 test:
 	uv run $(MAKE) _test
 
+PYTEST_MARK ?= live
+
 .PHONY: _livetest
 _livetest: | tests/cli.toml
-	pytest -v tests {%- if cookiecutter.glue %} pulp-glue{{ cookiecutter.__app_label_suffix }}/tests {%- endif %} -m live
+	pytest -v tests {%- if cookiecutter.glue %} pulp-glue{{ cookiecutter.__app_label_suffix }}/tests {%- endif %} -m "$(PYTEST_MARK)"
 
 .PHONY: livetest
 livetest:


### PR DESCRIPTION
Forgot to add this to the cookiecutter from #1419 