### PR TITLE
[PULP-1827] Add vulnerability report support for pulp_rpm

### DIFF
--- a/CHANGES/1427.feature
+++ b/CHANGES/1427.feature
@@ -1,0 +1,2 @@
+Added support for RPM vulnerability reports.
+This includes the `scan` subcommand for repository versions and the `--osv-config` option for repositories.

--- a/pulp-glue/src/pulp_glue/rpm/context.py
+++ b/pulp-glue/src/pulp_glue/rpm/context.py
@@ -371,6 +371,7 @@ class PulpRpmRepositoryVersionContext(PulpRepositoryVersionContext):
     HREF = "rpm_rpm_repository_version_href"
     ID_PREFIX = "repositories_rpm_rpm_versions"
     NEEDS_PLUGINS = [PluginRequirement("rpm", specifier=">=3.9.0")]
+    CAPABILITIES = {"scan": [PluginRequirement("rpm", specifier=">=3.38.0")]}
 
 
 class PulpRpmRepositoryContext(PulpRepositoryContext):
@@ -387,6 +388,7 @@ class PulpRpmRepositoryContext(PulpRepositoryContext):
         "roles": [PluginRequirement("rpm", specifier=">=3.19.0")],
     }
     NEEDS_PLUGINS = [PluginRequirement("rpm", specifier=">=3.9.0")]
+    NULLABLES = PulpRepositoryContext.NULLABLES | {"osv_config"}
 
     def preprocess_entity(self, body: EntityDefinition, partial: bool = False) -> EntityDefinition:
         body = super().preprocess_entity(body, partial=partial)

--- a/src/pulpcore/cli/rpm/repository.py
+++ b/src/pulpcore/cli/rpm/repository.py
@@ -204,6 +204,17 @@ update_options = [
         ),
         callback=load_json_callback,
     ),
+    pulp_option(
+        "--osv-config",
+        "osv_config",
+        needs_plugins=[PluginRequirement("rpm", specifier=">=3.38.0")],
+        help=_(
+            "A JSON list of ecosystem configs for vulnerability scanning via osv.dev "
+            "(or @file containing a JSON list). "
+            "Each entry must have 'name' and 'releases' keys. Pass '' to clear."
+        ),
+        callback=load_json_callback,
+    ),
 ]
 create_options = update_options + [click.option("--name", required=True)]
 

--- a/tests/scripts/pulp_rpm/test_vulnerability_report.sh
+++ b/tests/scripts/pulp_rpm/test_vulnerability_report.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -eu
+# shellcheck source=tests/scripts/config.source
+. "$(dirname "$(dirname "$(realpath "$0")")")"/config.source
+
+pulp debug has-plugin --name "core" --specifier ">=3.85.3" || exit 0
+pulp debug has-plugin --name "rpm" --specifier ">=3.38.0" || exit 0
+
+KERNEL_URL="https://vault.centos.org/7.0.1406/os/x86_64/Packages/kernel-3.10.0-123.el7.x86_64.rpm"
+OSV_CONFIG_A='[{"name": "AlmaLinux", "releases": ["9"]}]'
+OSV_CONFIG_B='[{"name": "Red Hat", "releases": ["cpe:/o:redhat:enterprise_linux:7::workstation"]}]'
+REPOSITORY=rpm_vulnerability_repo
+REPOSITORY_NO_CONFIG=rpm_vulnerability_repo_no_config
+
+cleanup () {
+  pulp rpm repository destroy --name ${REPOSITORY} || true
+  pulp rpm repository destroy --name ${REPOSITORY_NO_CONFIG} || true
+}
+trap cleanup EXIT
+
+
+get_osv_config(){
+  pulp rpm repository show --name "${1}" | jq '.osv_config'
+}
+
+# osv_config can be created
+expect_succ pulp rpm repository create --name ${REPOSITORY} --osv-config "${OSV_CONFIG_A}"
+test "$(get_osv_config $REPOSITORY)" != "null"
+
+# osv_config can be cleared
+expect_succ pulp rpm repository update --name ${REPOSITORY} --osv-config ""
+test "$(get_osv_config $REPOSITORY)" = "null"
+
+# osv_config can be modified
+expect_succ pulp rpm repository update --name ${REPOSITORY} --osv-config "${OSV_CONFIG_B}"
+test "$(get_osv_config $REPOSITORY)" != "null"
+
+# vulnerability generates a report
+pulp rpm content -t package create --file-url "${KERNEL_URL}" --repository ${REPOSITORY}
+expect_succ pulp rpm repository version scan --repository ${REPOSITORY}
+VULN_REPORT="$(pulp rpm repository version show --repository ${REPOSITORY} | jq -r '.vuln_report')"
+VULN_COUNT="$(pulp show --href "$VULN_REPORT" | jq '.results[0].vulns | length')"
+test "$VULN_COUNT" -gt 50  # kernels has lots of vuln reports
+
+# absence of osv_config fails
+pulp rpm repository create --name ${REPOSITORY_NO_CONFIG}
+expect_fail pulp rpm repository version scan --repository ${REPOSITORY_NO_CONFIG}


### PR DESCRIPTION
This adds the vulnerability report capability provided by pulpcore and
the rpm-specific vulnerability report configurations required by on the
rpm repository for the scan to work.

Closes #1427
