### PR TITLE
Add retain_checkpoints support to file and rpm repositories

### DIFF
--- a/CHANGES/1439.feature
+++ b/CHANGES/1439.feature
@@ -1,0 +1,1 @@
+Added the `--retain-checkpoints` option to file and rpm repositories.

--- a/pulp-glue/src/pulp_glue/common/context.py
+++ b/pulp-glue/src/pulp_glue/common/context.py
@@ -1582,7 +1582,7 @@ class PulpRepositoryContext(PulpEntityContext):
     HREF_TEMPLATE = "repositories/{plugin}/{resource_type}/{pulp_id}/"
     ID_PREFIX = "repositories"
     VERSION_CONTEXT: t.ClassVar[type[PulpRepositoryVersionContext]] = PulpRepositoryVersionContext
-    NULLABLES = {"description", "remote", "retain_repo_versions"}
+    NULLABLES = {"description", "remote", "retain_repo_versions", "retain_checkpoints"}
     TYPE_REGISTRY: t.Final[dict[str, type["PulpRepositoryContext"]]] = {}
 
     def __init_subclass__(cls, **kwargs: t.Any) -> None:

--- a/src/pulp_cli/generic.py
+++ b/src/pulp_cli/generic.py
@@ -1379,6 +1379,13 @@ retained_versions_option = pulp_option(
     type=int_or_empty,
 )
 
+retain_checkpoints_option = pulp_option(
+    "--retain-checkpoints",
+    needs_plugins=[PluginRequirement("core", specifier=">=3.106.0")],
+    help=_("Number of checkpoint publications to keep. Leave empty to retain all checkpoints."),
+    type=int_or_empty,
+)
+
 pulp_labels_option = pulp_option(
     "--labels",
     "pulp_labels",

--- a/src/pulpcore/cli/file/repository.py
+++ b/src/pulpcore/cli/file/repository.py
@@ -37,6 +37,7 @@ from pulp_cli.generic import (
     repository_href_option,
     repository_lookup_option,
     resource_option,
+    retain_checkpoints_option,
     retained_versions_option,
     role_command,
     show_command,
@@ -107,6 +108,7 @@ update_options = [
         default=None,
     ),
     retained_versions_option,
+    retain_checkpoints_option,
     pulp_labels_option,
 ]
 create_options = update_options + [click.option("--name", required=True)]

--- a/src/pulpcore/cli/rpm/repository.py
+++ b/src/pulpcore/cli/rpm/repository.py
@@ -37,6 +37,7 @@ from pulp_cli.generic import (
     repository_href_option,
     repository_lookup_option,
     resource_option,
+    retain_checkpoints_option,
     retained_versions_option,
     role_command,
     show_command,
@@ -194,6 +195,7 @@ update_options = [
         default=None,
     ),
     retained_versions_option,
+    retain_checkpoints_option,
     pulp_labels_option,
     pulp_option(
         "--repo-config",

--- a/tests/scripts/pulp_file/test_repository.sh
+++ b/tests/scripts/pulp_file/test_repository.sh
@@ -42,6 +42,17 @@ test "$(echo "$OUTPUT" | jq -r '.|length')" != "0"
 expect_succ pulp file repository task list --repository "cli_test_file_repo"
 test "$(echo "$OUTPUT" | jq -r '.|length')" = "6"
 
+# retain_checkpoints was added to Repository in pulpcore 3.106.0 (pulp/pulpcore#7428)
+if pulp debug has-plugin --name "core" --specifier ">=3.106.0"
+then
+  expect_succ pulp file repository update --repository "cli_test_file_repo" --retain-checkpoints 5
+  expect_succ pulp file repository show --repository "cli_test_file_repo"
+  test "$(echo "$OUTPUT" | jq -r '.retain_checkpoints')" = "5"
+  expect_succ pulp file repository update --repository "cli_test_file_repo" --retain-checkpoints ""
+  expect_succ pulp file repository show --repository "cli_test_file_repo"
+  test "$(echo "$OUTPUT" | jq -r '.retain_checkpoints')" = "null"
+fi
+
 if pulp debug has-plugin --name "file" --specifier ">=1.7.0"
 then
   expect_succ pulp file repository update --repository "cli_test_file_repo" --manifest "manifest.csv"

--- a/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
+++ b/tests/scripts/pulp_rpm/test_rpm_sync_publish.sh
@@ -36,6 +36,17 @@ expect_succ pulp rpm repository update --repository "cli_test_rpm_sync_repositor
 expect_succ pulp rpm repository show --repository "cli_test_rpm_sync_repository"
 test "$(echo "$OUTPUT" | jq -r '.description')" = "null"
 
+# retain_checkpoints was added to Repository in pulpcore 3.106.0 (pulp/pulpcore#7428)
+if pulp debug has-plugin --name "core" --specifier ">=3.106.0"
+then
+  expect_succ pulp rpm repository update --repository "cli_test_rpm_sync_repository" --retain-checkpoints 5
+  expect_succ pulp rpm repository show --repository "cli_test_rpm_sync_repository"
+  test "$(echo "$OUTPUT" | jq -r '.retain_checkpoints')" = "5"
+  expect_succ pulp rpm repository update --repository "cli_test_rpm_sync_repository" --retain-checkpoints ""
+  expect_succ pulp rpm repository show --repository "cli_test_rpm_sync_repository"
+  test "$(echo "$OUTPUT" | jq -r '.retain_checkpoints')" = "null"
+fi
+
 # sqlite metadata removal from pulp_rpm (pulp/pulp_rpm#3328)
 if pulp debug has-plugin --name "rpm" --specifier "<3.25.0"
 then


### PR DESCRIPTION
The retain_checkpoints field was added to Repository in pulpcore 3.106.0 (pulp/pulpcore#7428) and is exposed by the file and rpm repository APIs. This adds the corresponding --retain-checkpoints option to the file and rpm repository create and update commands. These are the only two plugins that currently support checkpoints in the CLI.

fixes #1439

Assisted By: GitHub Copilot (Claude Opus 4.8)