### PR TITLE
Add --distribution filter to container content list.

### DIFF
--- a/CHANGES/+distribution-content-filter.feature
+++ b/CHANGES/+distribution-content-filter.feature
@@ -1,0 +1,1 @@
+Added `--distribution` filter to `pulp container content list` to resolve the served repository version and list tags (or other content) for that image.

--- a/pulp-glue/src/pulp_glue/common/context.py
+++ b/pulp-glue/src/pulp_glue/common/context.py
@@ -342,7 +342,7 @@ class PulpContext:
             # If this is "only" true and we have the PULP_CA_BUNDLE variable set, use it.
             self.verify_ssl = os.environ.get("PULP_CA_BUNDLE", True)
         self._needed_plugins: list[PluginRequirement] = [
-            PluginRequirement("core", specifier=">=3.11.0")
+            PluginRequirement("core", specifier=">=3.49.0")
         ]
         self.pulp_domain: str = domain
 

--- a/src/pulpcore/cli/container/content.py
+++ b/src/pulpcore/cli/container/content.py
@@ -3,21 +3,31 @@ import typing as t
 
 import click
 
-from pulp_glue.common.context import PluginRequirement, PulpContentContext
+from pulp_glue.common.context import (
+    EntityDefinition,
+    PluginRequirement,
+    PulpContentContext,
+    PulpDistributionContext,
+)
 from pulp_glue.container.context import (
     PulpContainerBlobContext,
+    PulpContainerDistributionContext,
     PulpContainerManifestContext,
+    PulpContainerRepositoryContext,
     PulpContainerTagContext,
 )
 
 from pulp_cli.generic import (
+    PulpCLIContext,
     content_filter_options,
     href_option,
     label_command,
     list_command,
     option_group,
+    option_processor,
     pulp_group,
     pulp_option,
+    resource_option,
     show_command,
     type_option,
 )
@@ -34,6 +44,39 @@ def _content_callback(ctx: click.Context, value: dict[str, t.Any]) -> None:
         entity_ctx.entity = value
 
 
+def _repository_version_from_distribution(
+    pulp_ctx: PulpCLIContext, distribution: EntityDefinition
+) -> str:
+    if repository_version := distribution.get("repository_version"):
+        return t.cast(str, repository_version)
+
+    repository_href = distribution.get("repository")
+    if not repository_href:
+        raise click.ClickException(
+            _(
+                "Distribution '{name}' is not associated with a repository or repository version."
+            ).format(name=distribution.get("name", ""))
+        )
+    repo_ctx = PulpContainerRepositoryContext(pulp_ctx, pulp_href=repository_href)
+
+    return t.cast(str, repo_ctx.entity["latest_version_href"])
+
+
+def _process_distribution_filter(ctx: click.Context) -> None:
+    if distribution := ctx.params.pop("distribution", None):
+        if ctx.params.get("repository_version"):
+            raise click.UsageError(
+                _("Cannot use --distribution together with --repository-version.")
+            )
+
+        assert isinstance(distribution, PulpContainerDistributionContext)
+        pulp_ctx = ctx.find_object(PulpCLIContext)
+        assert pulp_ctx is not None
+        ctx.params["repository_version"] = _repository_version_from_distribution(
+            pulp_ctx, distribution.entity
+        )
+
+
 @pulp_group()
 @type_option(
     choices={
@@ -45,6 +88,20 @@ def _content_callback(ctx: click.Context, value: dict[str, t.Any]) -> None:
 )
 def content() -> None:
     pass
+
+
+distribution_filter_option = resource_option(
+    "--distribution",
+    default_plugin="container",
+    default_type="container",
+    context_table={
+        "container:container": PulpContainerDistributionContext,
+    },
+    href_pattern=PulpDistributionContext.HREF_PATTERN,
+    help=_(
+        "Filter {entities} by the repository version served by this distribution (name or href)."
+    ),
+)
 
 
 list_options = [
@@ -86,6 +143,8 @@ list_options = [
         allowed_with_contexts=(PulpContainerManifestContext,),
     ),
     *content_filter_options,
+    distribution_filter_option,
+    option_processor(callback=_process_distribution_filter),
 ]
 
 lookup_options = [

--- a/src/pulpcore/cli/container/distribution.py
+++ b/src/pulpcore/cli/container/distribution.py
@@ -5,7 +5,6 @@ import click
 from pulp_glue.common.context import (
     EntityDefinition,
     EntityFieldDefinition,
-    PluginRequirement,
     PulpEntityContext,
     PulpRepositoryContext,
 )
@@ -104,9 +103,6 @@ def update(
 
     distribution: EntityDefinition = distribution_ctx.entity
     body: EntityDefinition = {}
-    non_blocking = base_path is None and distribution_ctx.pulp_ctx.has_plugin(
-        PluginRequirement("core", specifier=">=3.24.0")
-    )
 
     if private is not None:
         body["private"] = private
@@ -127,18 +123,16 @@ def update(
             repository = t.cast(PulpEntityContext, repository)
             if version is not None:
                 if distribution["repository"]:
-                    distribution_ctx.update(body={"repository": ""}, non_blocking=non_blocking)
+                    body["repository"] = ""
                 body["repository_version"] = f"{repository.pulp_href}versions/{version}/"
             else:
                 if distribution["repository_version"]:
-                    distribution_ctx.update(
-                        body={"repository_version": ""}, non_blocking=non_blocking
-                    )
+                    body["repository_version"] = ""
                 body["repository"] = repository.pulp_href
     elif version is not None:
         # keep current repository, change version
         if distribution["repository"]:
-            distribution_ctx.update(body={"repository": ""}, non_blocking=non_blocking)
+            body["repository"] = ""
             body["repository_version"] = f"{distribution['repository']}versions/{version}/"
         elif distribution["repository_version"]:
             # 'dummy' vars are to get us around a mypy/1.2 complaint about '_'

--- a/tests/scripts/pulp_container/test_content.sh
+++ b/tests/scripts/pulp_container/test_content.sh
@@ -7,6 +7,7 @@ set -eu
 pulp debug has-plugin --name "container" || exit 23
 
 cleanup() {
+  pulp container distribution destroy --name "cli_test_container_content_distro" || true
   pulp container repository destroy --name "cli_test_container_content_repository" || true
   pulp container remote destroy --name "cli_test_container_content_remote" || true
 }
@@ -16,6 +17,9 @@ trap cleanup EXIT
 pulp container remote create --name "cli_test_container_content_remote" --url "$CONTAINER_REMOTE_URL" --upstream-name "$CONTAINER_IMAGE"
 pulp container repository create --name "cli_test_container_content_repository"
 pulp container repository sync --name "cli_test_container_content_repository" --remote "cli_test_container_content_remote"
+pulp container distribution create --name "cli_test_container_content_distro" \
+  --base-path "cli_test_container_content_distro" \
+  --repository "cli_test_container_content_repository"
 
 # Check each content list
 expect_succ pulp container content -t blob list
@@ -69,3 +73,13 @@ test "$(echo "$OUTPUT" | jq -r length)" -ge "1"
 
 expect_succ pulp container content -t blob list --digest "$blob_digest"
 test "$(echo "$OUTPUT" | jq -r length)" -ge "1"
+
+# Filter tags by repository version and by distribution (resolves to repository version)
+repo_ver_href="$(pulp container repository show --name "cli_test_container_content_repository" | jq -r .latest_version_href)"
+expect_succ pulp container content -t tag list --repository-version "$repo_ver_href"
+test "$(echo "$OUTPUT" | jq -r length)" -ge "1"
+expect_succ pulp container content -t tag list --distribution "cli_test_container_content_distro"
+test "$(echo "$OUTPUT" | jq -r length)" -ge "1"
+expect_fail pulp container content -t tag list \
+  --distribution "cli_test_container_content_distro" \
+  --repository-version "$repo_ver_href"


### PR DESCRIPTION
Resolve the served repository version from a distribution so users can list tags and other content for an image without manual lookup steps.

Ref: https://github.com/pulp/pulp_container/issues/2164