### PR TITLE
Honor PYTEST_MARK in make paralleltest

### DIFF
--- a/CHANGES/+paralleltest-pytest-mark.misc
+++ b/CHANGES/+paralleltest-pytest-mark.misc
@@ -1,0 +1,1 @@
+Honor PYTEST_MARK in `make paralleltest`, matching livetest, so plugin CI can filter parallel livetests.

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ livetest:
 
 .PHONY: _paralleltest
 _paralleltest: | tests/cli.toml
-	pytest -v tests pulp-glue/tests -m live -n 8
+	pytest -v tests pulp-glue/tests -m "$(PYTEST_MARK)" -n 8
 
 .PHONY: paralleltest
 paralleltest:


### PR DESCRIPTION
## Summary
- Make `_paralleltest` use `$(PYTEST_MARK)` instead of hardcoding `-m live`, matching `livetest`.
- Lets plugin CI run filtered parallel livetests, e.g. `make paralleltest PYTEST_MARK="live and (pulpcore or pulp_file or pulp_certguard)"`.

## Test plan
- [ ] `make paralleltest` still defaults to `-m live` (`PYTEST_MARK ?= live`)
- [ ] `make paralleltest PYTEST_MARK="live and pulpcore"` only selects matching tests


Made with [Cursor](https://cursor.com)